### PR TITLE
fix(communities/achievements): fixing the achievements tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 # CapacitorJS build files
 frontend/ios
 frontend/android
+
+# Promt files
+.github/prompts

--- a/frontend/src/features/communities/hooks/useInfiniteAchievements.ts
+++ b/frontend/src/features/communities/hooks/useInfiniteAchievements.ts
@@ -1,0 +1,41 @@
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
+import * as Routes from "@/data/routes";
+
+export type Achievement = {
+  id: number;
+  community_id: number;
+  description: string;
+  year: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type UseInfiniteAchievementsParams = {
+  communityId: number | null | undefined;
+  size?: number;
+  enabled?: boolean;
+};
+
+export function useInfiniteAchievements(params: UseInfiniteAchievementsParams) {
+  const { communityId, size = 20 } = params;
+
+  const result = useInfiniteScroll<Achievement>({
+    queryKey: ["campusCurrent", "community", String(communityId ?? 0), "achievements"],
+    apiEndpoint: `/${Routes.COMMUNITIES}/${communityId}/achievements`,
+    size,
+    additionalParams: {},
+    transformResponse: (response: any) => {
+      // Transform the response to match the expected format
+      return {
+        items: response.achievements ?? [],
+        total_pages: response.total_pages ?? 1,
+        page: response.page ?? 1,
+      };
+    },
+  });
+
+  return {
+    ...result,
+    achievements: result.items,
+  };
+}


### PR DESCRIPTION
1. Achievements would disappear when navigating away from the "Student Awards" tab and coming back. The old implementation cleared the achievements state when leaving the tab, and the query was disabled when not on the tab. Removed the clearing logic and enabled the query whenever the community exists, utilizing React Query's cache.
2. Refreshing the page would always navigate back to the "About" tab, even if the user was on another tab. To make it persistent, implemented URL-based tab state using `useSearchParams` from react-router-dom. The active tab is now stored in the URL query parameter `?tab=[tab]`.
3. Implemented automatic infinite scroll using `IntersectionObserver`, matching the pattern used for events.