### PR TITLE
fix(infra): resolve fastapi dynamically in dev nginx

### DIFF
--- a/infra/nginx/nginx.dev.conf
+++ b/infra/nginx/nginx.dev.conf
@@ -5,7 +5,9 @@ events {
 http {
     include       mime.types;
     default_type  application/octet-stream;
-    resolver 127.0.0.11 ipv6=off;
+    # Resolve Docker service names at request time. Containers receive a new
+    # IP when recreated during development, so keep this cache short.
+    resolver 127.0.0.11 valid=5s ipv6=off;
 
     # Prefer client scheme provided by Cloudflare/Cloudflared when present
     map $http_x_forwarded_proto $client_scheme {
@@ -40,9 +42,12 @@ http {
         server_name localhost;
         client_max_body_size 100m;
 
+        # Variables make proxy_pass resolve Docker service names dynamically.
+        set $fastapi_upstream http://fastapi:8000;
+
         # Proxy WebSocket requests directly to FastAPI 
         location /ws/ {
-            proxy_pass http://fastapi:8000/ws/;
+            proxy_pass $fastapi_upstream;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -56,7 +61,7 @@ http {
         
         # Serve all other requests from FastAPI
         location /api/ {
-            proxy_pass http://fastapi:8000;
+            proxy_pass $fastapi_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Description
Fixes stale FastAPI Docker DNS resolution in the development Nginx configuration.

After recreating the FastAPI container, Nginx could keep its old container IP and return 502 responses. The config now resolves the FastAPI service dynamically with a short DNS cache.

## Type of Change
- [x] 🐛 Bug fix

## Testing
- [x] nginx -t
- [x] Recreated FastAPI without restarting Nginx
- [x] Verified GET /api/login returns 303