### PR TITLE
fix(courses): show sync when no courses are registered

### DIFF
--- a/frontend/src/features/courses/components/live-gpa-tab.tsx
+++ b/frontend/src/features/courses/components/live-gpa-tab.tsx
@@ -221,9 +221,19 @@ export function LiveGpaTab({ user, login, viewModel }: LiveGpaTabProps) {
           </Button>
         </div>
       ) : registeredCourses.length === 0 ? (
-        <div className={cn("rounded-[18px] border py-12 text-center text-sm text-muted-foreground", coursesSurface.cardLg)}>
+        <div className={cn("rounded-[18px] p-6 text-center text-sm text-muted-foreground", coursesSurface.cardLg)}>
           <Calculator className="mx-auto mb-4 h-12 w-12 opacity-50" />
           <p>No courses registered yet. Use Sync to import your schedule.</p>
+          <div className="mx-auto mt-6 max-w-md">
+            <CoursesSyncToolbar
+              viewModel={{ syncCourses, syncCoursesFromPdf, schedule }}
+              userEmail={userEmail}
+              onImportCalendar={() => setIsImportModalOpen(true)}
+              isExporting={isExporting}
+              showCalendar={false}
+              plain
+            />
+          </div>
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-[260px_minmax(0,1fr)_300px] xl:items-start">

--- a/frontend/src/features/courses/components/live-gpa/courses-sync-toolbar.tsx
+++ b/frontend/src/features/courses/components/live-gpa/courses-sync-toolbar.tsx
@@ -14,6 +14,10 @@ interface CoursesSyncToolbarProps {
   isExporting: boolean;
   /** Footer inside the courses picker card. */
   embedded?: boolean;
+  /** Calendar export is available only after a schedule has been imported. */
+  showCalendar?: boolean;
+  /** Render only the centered sync control for an empty state. */
+  plain?: boolean;
 }
 
 export function CoursesSyncToolbar({
@@ -22,6 +26,8 @@ export function CoursesSyncToolbar({
   onImportCalendar,
   isExporting,
   embedded = false,
+  showCalendar = true,
+  plain = false,
 }: CoursesSyncToolbarProps) {
   const lastSynced = viewModel.schedule.lastSyncedText;
 
@@ -35,83 +41,87 @@ export function CoursesSyncToolbar({
             onSyncPdf={viewModel.syncCoursesFromPdf}
             userEmail={userEmail}
           />
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 min-w-0 flex-1 gap-1.5 rounded-lg px-2 text-[12px] font-medium"
-            onClick={onImportCalendar}
-            disabled={isExporting}
-            title="Import to Google Calendar"
-          >
-            <img
-              src={
-                typeof GoogleCalendarIcon === "string"
-                  ? GoogleCalendarIcon
-                  : (GoogleCalendarIcon as { src: string }).src
-              }
-              alt=""
-              className="h-3.5 w-3.5 shrink-0"
-            />
-            <span className="truncate">{isExporting ? "…" : "Calendar"}</span>
-          </Button>
-        </div>
-        <div className="flex items-center gap-1.5 px-0.5 text-[11px] text-muted-foreground">
-          {lastSynced ? (
-            <>
-              <CheckCircle2 className="h-3 w-3 shrink-0 text-green-600 dark:text-green-400" />
-              <span className="truncate">Synced {lastSynced}</span>
-            </>
-          ) : (
-            <span>Not synced yet</span>
+          {showCalendar && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h- min-w-0 flex-1 gap-1.5 rounded-lg px-2 text-[12px] font-medium"
+              onClick={onImportCalendar}
+              disabled={isExporting}
+              title="Import to Google Calendar"
+            >
+              <img
+                src={
+                  typeof GoogleCalendarIcon === "string"
+                    ? GoogleCalendarIcon
+                    : (GoogleCalendarIcon as { src: string }).src
+                }
+                alt=""
+                className="h-3.5 w-3.5 shrink-0"
+              />
+              <span className="truncate">{isExporting ? "…" : "Calendar"}</span>
+            </Button>
           )}
         </div>
+        {lastSynced && (
+          <div className="flex items-center gap-1.5 px-0.5 text-[11px] text-muted-foreground">
+            <CheckCircle2 className="h-3 w-3 shrink-0 text-green-600 dark:text-green-400" />
+            <span className="truncate">Synced {lastSynced}</span>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div className={cn("flex h-12 items-center justify-between gap-3 rounded-[14px] border border-border bg-card px-3")}>
-      <div className="flex min-w-0 items-center gap-3">
+    <div
+      className={cn(
+        plain
+          ? "flex items-center justify-center py-2"
+          : "flex h-12 items-center justify-between gap-3 rounded-[14px] border border-border bg-card px-3",
+      )}
+    >
+      <div className="flex min-w-5 items-center gap-3">
         <SynchronizeCoursesControl
           compact
           onSync={viewModel.syncCourses}
           onSyncPdf={viewModel.syncCoursesFromPdf}
           userEmail={userEmail}
         />
-        <div className="hidden h-4 w-px bg-border sm:block" />
-        <div className="hidden min-w-0 items-center gap-1.5 text-[13px] text-muted-foreground sm:flex">
-          {lastSynced ? (
-            <>
+        {lastSynced && (
+          <>
+            <div className="hidden h-4 w-px bg-border sm:block" />
+            <div className="hidden min-w-0 items-center gap-1.5 text-[13px] text-muted-foreground sm:flex">
               <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-400" />
               <span className="truncate">
                 Last synced <span className="text-foreground">{lastSynced}</span>
               </span>
-            </>
-          ) : (
-            <span>Not synced yet</span>
-          )}
-        </div>
+            </div>
+          </>
+        )}
       </div>
 
-      <Button
-        size="sm"
-        variant="outline"
-        className="h-8 shrink-0 gap-1.5 rounded-lg px-3 text-[13px] font-medium"
-        onClick={onImportCalendar}
-        disabled={isExporting}
-      >
-        <img
-          src={
-            typeof GoogleCalendarIcon === "string"
-              ? GoogleCalendarIcon
-              : (GoogleCalendarIcon as { src: string }).src
-          }
-          alt=""
-          className="h-3.5 w-3.5"
-        />
-        <span className="hidden md:inline">{isExporting ? "Importing…" : "Import to Google Calendar"}</span>
-        <span className="md:hidden">{isExporting ? "…" : "Calendar"}</span>
-      </Button>
+      {showCalendar && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8 shrink-0 gap-1.5 rounded-lg px-3 text-[13px] font-medium"
+          onClick={onImportCalendar}
+          disabled={isExporting}
+        >
+          <img
+            src={
+              typeof GoogleCalendarIcon === "string"
+                ? GoogleCalendarIcon
+                : (GoogleCalendarIcon as { src: string }).src
+            }
+            alt=""
+            className="h-3.5 w-3.5"
+          />
+          <span className="hidden md:inline">{isExporting ? "Importing…" : "Import to Google Calendar"}</span>
+          <span className="md:hidden">{isExporting ? "…" : "Calendar"}</span>
+        </Button>
+      )}
     </div>
   );
 }

--- a/frontend/src/features/courses/components/synchronize-courses-control.tsx
+++ b/frontend/src/features/courses/components/synchronize-courses-control.tsx
@@ -178,12 +178,12 @@ export function SynchronizeCoursesControl({
 
   return (
     <>
-      <div className={`inline-flex overflow-hidden ${compact ? "rounded-lg" : "rounded-full"}`}>
+      <div className={`inline-flex items-center gap-1.5 ${compact ? "rounded-lg" : "rounded-full"}`}>
         <Button
           size="sm"
           variant="outline"
           onClick={() => handleOpen("registrar")}
-          className={`font-medium gap-1.5 ${compact ? "h-8 rounded-l-lg px-3 text-[13px]" : "rounded-none rounded-l-full px-4 gap-2"}`}
+          className={`font-medium gap-1.5 ${compact ? "h-8 rounded-lg px-3 text-[13px]" : "rounded-full px-4 gap-2"}`}
         >
           <RefreshCcw className={compact ? "h-3.5 w-3.5" : "h-4 w-4"} />
           Sync
@@ -193,7 +193,7 @@ export function SynchronizeCoursesControl({
             <Button
               size="sm"
               variant="outline"
-              className={`border-l-0 ${compact ? "h-8 rounded-r-lg px-2" : "rounded-none rounded-r-full px-2"}`}
+              className={`${compact ? "h-8 rounded-lg px-2" : "rounded-full px-2"}`}
               aria-label="More sync options"
             >
               <ChevronDown className={compact ? "h-3.5 w-3.5" : "h-4 w-4"} />


### PR DESCRIPTION
## Description

Fixes the Live GPA empty state so a user can synchronize their courses before any courses are registered.

## Changes

- Show and center the Sync control when the course list is empty.
- Remove the empty-state border.
- Add spacing between the Sync button and its dropdown.
- Remove the “Not synced yet” status before the first sync.
- Hide Google Calendar export until a schedule has been imported.

## Testing

- no testing