### PR TITLE
fix(communities): validate community URLs

### DIFF
--- a/backend/modules/campuscurrent/communities/schemas.py
+++ b/backend/modules/campuscurrent/communities/schemas.py
@@ -1,5 +1,7 @@
+import re
 from datetime import date, datetime
-from typing import List
+from typing import List, Literal
+from urllib.parse import SplitResult, urlsplit
 
 from fastapi import Query
 from pydantic import BaseModel, EmailStr, Field, HttpUrl, field_serializer, field_validator
@@ -12,6 +14,70 @@ from backend.core.database.models.community import (
     CommunityRecruitmentStatus,
     CommunityType,
 )
+
+
+_URL_SCHEME_PATTERN = re.compile(r"^[a-z][a-z\d+.-]*:", re.IGNORECASE)
+_SOCIAL_HOSTS = {
+    "telegram": {"t.me", "telegram.me"},
+    "instagram": {"instagram.com", "instagr.am"},
+}
+
+
+def _normalize_optional_url(value: object) -> str | None:
+    if value is None:
+        return None
+
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+    if not _URL_SCHEME_PATTERN.match(normalized):
+        return f"https://{normalized}"
+    return normalized
+
+
+def _parse_http_url(value: str, error_message: str) -> SplitResult:
+    if value.count("://") != 1:
+        raise ValueError(error_message)
+
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError:
+        raise ValueError(error_message) from None
+
+    if parsed.scheme not in {"http", "https"} or not hostname:
+        raise ValueError(error_message)
+    return parsed
+
+
+def _validate_social_url(
+    value: object,
+    *,
+    platform: Literal["telegram", "instagram"],
+    error_message: str,
+) -> str | None:
+    normalized = _normalize_optional_url(value)
+    if normalized is None:
+        return None
+
+    parsed = _parse_http_url(normalized, error_message)
+    hostname = parsed.hostname.lower().removeprefix("www.")
+    if hostname not in _SOCIAL_HOSTS[platform]:
+        raise ValueError(error_message)
+    return normalized
+
+
+def _validate_recruitment_url(value: object) -> str | None:
+    error_message = "Enter an HTTPS URL"
+    normalized = _normalize_optional_url(value)
+    if normalized is None:
+        return None
+
+    parsed = _parse_http_url(normalized, error_message)
+    if parsed.scheme != "https":
+        raise ValueError(error_message)
+    return normalized
 
 
 # Achievement Schemas
@@ -215,27 +281,28 @@ class CommunityCreateRequest(BaseModel):
         example="https://www.instagram.com/nufencingclub",
     )
 
-    @field_validator("telegram_url", "instagram_url", mode="before")
-    def normalize_social_url(cls, value):
-        if value is None:
-            return None
-        value = value.strip()
-        if value == "":
-            return None
-        if not value.startswith(("http://", "https://")):
-            return f"https://{value}"
-        return value
+    @field_validator("telegram_url", mode="before")
+    @classmethod
+    def validate_telegram_url(cls, value: object) -> str | None:
+        return _validate_social_url(
+            value,
+            platform="telegram",
+            error_message="Enter a Telegram URL",
+        )
+
+    @field_validator("instagram_url", mode="before")
+    @classmethod
+    def validate_instagram_url(cls, value: object) -> str | None:
+        return _validate_social_url(
+            value,
+            platform="instagram",
+            error_message="Enter an Instagram URL",
+        )
 
     @field_validator("recruitment_link", mode="before")
-    def normalize_recruitment_link(cls, value):
-        if value is None:
-            return None
-        value = str(value).strip()
-        if value == "":
-            return None
-        if not value.startswith(("http://", "https://")):
-            return f"https://{value}"
-        return value
+    @classmethod
+    def validate_recruitment_link(cls, value: object) -> str | None:
+        return _validate_recruitment_url(value)
 
     @field_serializer("recruitment_link")
     def serialize_recruitment_link(self, value: HttpUrl | None) -> str | None:
@@ -338,27 +405,28 @@ class CommunityUpdateRequest(BaseModel):
     class Config:
         from_attributes = True  # Make sure it can be used with SQLAlchemy models
 
-    @field_validator("telegram_url", "instagram_url", mode="before")
-    def normalize_social_url_update(cls, value):
-        if value is None:
-            return None
-        value = value.strip()
-        if value == "":
-            return None
-        if not value.startswith(("http://", "https://")):
-            return f"https://{value}"
-        return value
+    @field_validator("telegram_url", mode="before")
+    @classmethod
+    def validate_telegram_url(cls, value: object) -> str | None:
+        return _validate_social_url(
+            value,
+            platform="telegram",
+            error_message="Enter a Telegram URL",
+        )
+
+    @field_validator("instagram_url", mode="before")
+    @classmethod
+    def validate_instagram_url(cls, value: object) -> str | None:
+        return _validate_social_url(
+            value,
+            platform="instagram",
+            error_message="Enter an Instagram URL",
+        )
 
     @field_validator("recruitment_link", mode="before")
-    def normalize_recruitment_link_update(cls, value):
-        if value is None:
-            return None
-        value = str(value).strip()
-        if value == "":
-            return None
-        if not value.startswith(("http://", "https://")):
-            return f"https://{value}"
-        return value
+    @classmethod
+    def validate_recruitment_link(cls, value: object) -> str | None:
+        return _validate_recruitment_url(value)
 
 
 class ListCommunity(BaseModel):

--- a/backend/modules/campuscurrent/communities/tests/test_community_url_validation.py
+++ b/backend/modules/campuscurrent/communities/tests/test_community_url_validation.py
@@ -1,0 +1,68 @@
+from datetime import date
+from typing import Callable
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from backend.core.database.models.community import (
+    CommunityCategory,
+    CommunityRecruitmentStatus,
+    CommunityType,
+)
+from backend.modules.campuscurrent.communities.schemas import (
+    CommunityCreateRequest,
+    CommunityUpdateRequest,
+)
+
+
+def create_community(**overrides: object) -> CommunityCreateRequest:
+    values = {
+        "name": "Test Community",
+        "type": CommunityType.club,
+        "category": CommunityCategory.academic,
+        "recruitment_status": CommunityRecruitmentStatus.closed,
+        "description": "Community used for validation tests",
+        "established": date(2025, 1, 1),
+        "head": "test-user",
+    }
+    values.update(overrides)
+    return CommunityCreateRequest(**values)
+
+
+ModelFactory = Callable[..., BaseModel]
+
+
+@pytest.mark.parametrize("model_factory", [create_community, CommunityUpdateRequest])
+def test_normalizes_valid_community_urls(model_factory: ModelFactory):
+    community = model_factory(
+        telegram_url=" www.t.me/community ",
+        instagram_url="instagr.am/community",
+        recruitment_link="example.com/apply",
+    )
+
+    assert community.telegram_url == "https://www.t.me/community"
+    assert community.instagram_url == "https://instagr.am/community"
+    assert str(community.recruitment_link) == "https://example.com/apply"
+
+
+@pytest.mark.parametrize("model_factory", [create_community, CommunityUpdateRequest])
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("telegram_url", "https://telegram.org/community", "Enter a Telegram URL"),
+        ("telegram_url", "https://t.me:invalid/community", "Enter a Telegram URL"),
+        ("telegram_url", "https://wtf://t.me/community", "Enter a Telegram URL"),
+        ("instagram_url", "https://help.instagram.com/community", "Enter an Instagram URL"),
+        ("instagram_url", "wtf://instagram.com/community", "Enter an Instagram URL"),
+        ("recruitment_link", "http://example.com/apply", "Enter an HTTPS URL"),
+        ("recruitment_link", "https://wtf://example.com", "Enter an HTTPS URL"),
+    ],
+)
+def test_rejects_invalid_community_urls(
+    model_factory: ModelFactory,
+    field: str,
+    value: str,
+    message: str,
+):
+    with pytest.raises(ValidationError, match=message):
+        model_factory(**{field: value})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",
     "build": "vite build",
-    "start": "vite preview --host 0.0.0.0 --port 5173"
+    "start": "vite preview --host 0.0.0.0 --port 5173",
+    "test:url-validation": "tsx --test src/features/communities/utils/url-validation.test.ts"
   },
   "dependencies": {
     "@capacitor/core": "^8.0.0",

--- a/frontend/src/context/community-form-context.tsx
+++ b/frontend/src/context/community-form-context.tsx
@@ -12,6 +12,12 @@ import {
   CommunityEditableFields,
   CommunityPermissions,
 } from "@/features/shared/campus/types";
+import {
+  getHttpsUrlError,
+  getInstagramUrlError,
+  getTelegramUrlError,
+  normalizeHttpUrl,
+} from "@/features/communities/utils/url-validation";
 
 interface CommunityFormContextType {
   formData: CreateCommunityData | EditCommunityData;
@@ -106,7 +112,7 @@ export function CommunityFormProvider({
     ) {
       return;
     }
-    setFormData({ ...formData, [name]: value });
+    setFormData((currentFormData) => ({ ...currentFormData, [name]: value }));
   };
 
   const handleSelectChange = (name: string, value: string) => {
@@ -155,16 +161,6 @@ export function CommunityFormProvider({
 
   const validateForm = (): { isValid: boolean; errors: string[] } => {
     const errors: string[] = [];
-    const ensureHttp = (val: string | undefined | null): string | undefined => {
-      if (!val) return undefined;
-      const trimmed = val.trim();
-      if (!trimmed) return undefined;
-      if (!/^https?:\/\//i.test(trimmed)) {
-        return `https://${trimmed}`;
-      }
-      return trimmed;
-    };
-    
     // Name validation (required, 3-100 characters)
     if (!formData.name || formData.name.trim().length < 3) {
       errors.push("Community name must be at least 3 characters long");
@@ -207,19 +203,13 @@ export function CommunityFormProvider({
     
     // Recruitment link validation (required when status is open)
     if (formData.recruitment_status === CommunityRecruitmentStatus.open) {
-      const normalizedLink = ensureHttp((formData as any).recruitment_link as string);
-      (formData as any).recruitment_link = normalizedLink || "";
-      const link = normalizedLink;
+      const link = normalizeHttpUrl((formData as any).recruitment_link as string);
       if (!link) {
         errors.push("Recruitment link is required when recruitment status is open");
       } else {
-        try {
-          const url = new URL(link);
-          if (url.protocol !== "http:" && url.protocol !== "https:") {
-            errors.push("Recruitment link must be a valid HTTP or HTTPS URL");
-          }
-        } catch {
-          errors.push("Recruitment link must be a valid URL");
+        const linkError = getHttpsUrlError(link);
+        if (linkError) {
+          errors.push(`Recruitment link: ${linkError}`);
         }
       }
     }
@@ -230,28 +220,20 @@ export function CommunityFormProvider({
     }
     
     // URL validation for social media links
-    const validateOptionalUrl = (url: string | undefined, fieldName: string) => {
-      const normalized = ensureHttp(url);
-      if (normalized) {
-        try {
-          const validUrl = new URL(normalized);
-          if (validUrl.protocol !== "http:" && validUrl.protocol !== "https:") {
-            errors.push(`${fieldName} must be a valid HTTP or HTTPS URL`);
-          }
-        } catch {
-          errors.push(`${fieldName} must be a valid URL`);
-        }
-      }
-      // write back normalization so the submit uses it
-      if (fieldName === "Telegram URL") {
-        (formData as any).telegram_url = normalized as any;
-      } else if (fieldName === "Instagram URL") {
-        (formData as any).instagram_url = normalized as any;
+    const validateOptionalUrl = (
+      url: string | undefined,
+      fieldName: string,
+      getUrlError: (value: string) => string | undefined,
+    ) => {
+      const normalized = normalizeHttpUrl(url);
+      const urlError = normalized ? getUrlError(normalized) : undefined;
+      if (urlError) {
+        errors.push(`${fieldName}: ${urlError}`);
       }
     };
     
-    validateOptionalUrl(formData.telegram_url as any, "Telegram URL");
-    validateOptionalUrl(formData.instagram_url as any, "Instagram URL");
+    validateOptionalUrl(formData.telegram_url, "Telegram URL", getTelegramUrlError);
+    validateOptionalUrl(formData.instagram_url, "Instagram URL", getInstagramUrlError);
     
     return {
       isValid: errors.length === 0,
@@ -288,5 +270,3 @@ export function useCommunityForm() {
   }
   return context;
 }
-
-

--- a/frontend/src/features/communities/components/community-details-form.tsx
+++ b/frontend/src/features/communities/components/community-details-form.tsx
@@ -6,7 +6,12 @@ import { Label } from "@/components/atoms/label";
 import { CommunityRecruitmentStatus, CommunityType, CommunityCategory } from "@/features/shared/campus/types";
 import { format } from "date-fns";
 import { useState, useEffect } from "react";
-import { useToast } from "@/hooks/use-toast";
+import {
+  getHttpsUrlError,
+  getInstagramUrlError,
+  getTelegramUrlError,
+  normalizeHttpUrl,
+} from "@/features/communities/utils/url-validation";
 
 export function CommunityDetailsForm() {
   const {
@@ -16,8 +21,6 @@ export function CommunityDetailsForm() {
     isFieldEditable,
     isEditMode,
   } = useCommunityForm();
-  const { toast } = useToast();
-
   // State for the date picker
   const [date, setDate] = useState<Date | undefined>(undefined);
 
@@ -53,15 +56,19 @@ export function CommunityDetailsForm() {
   const showRecruitmentLink =
     formData.recruitment_status === CommunityRecruitmentStatus.open;
 
-  const isValidUrl = (value: string): boolean => {
-    if (!value) return true;
-    try {
-      const url = new URL(value);
-      return url.protocol === "http:" || url.protocol === "https:";
-    } catch {
-      return false;
-    }
-  };
+  const normalizedTelegramUrl = normalizeHttpUrl(formData.telegram_url);
+  const telegramUrlError = normalizedTelegramUrl
+    ? getTelegramUrlError(normalizedTelegramUrl)
+    : undefined;
+  const normalizedInstagramUrl = normalizeHttpUrl(formData.instagram_url);
+  const instagramUrlError = normalizedInstagramUrl
+    ? getInstagramUrlError(normalizedInstagramUrl)
+    : undefined;
+  const recruitmentLink = (formData as { recruitment_link?: string }).recruitment_link;
+  const normalizedRecruitmentUrl = normalizeHttpUrl(recruitmentLink);
+  const recruitmentUrlError = normalizedRecruitmentUrl
+    ? getHttpsUrlError(normalizedRecruitmentUrl)
+    : undefined;
 
   return (
     <div className="space-y-4">
@@ -141,7 +148,14 @@ export function CommunityDetailsForm() {
             value={formData.telegram_url}
             onChange={handleInputChange}
             disabled={!isFieldEditable("telegram_url")}
+            aria-invalid={Boolean(telegramUrlError)}
+            aria-describedby={telegramUrlError ? "telegram_url-error" : undefined}
           />
+          {telegramUrlError && (
+            <p id="telegram_url-error" role="alert" className="mt-1 text-xs text-destructive">
+              {telegramUrlError}
+            </p>
+          )}
         </div>
         <div>
           <Label htmlFor="instagram_url">Instagram URL</Label>
@@ -151,7 +165,14 @@ export function CommunityDetailsForm() {
             value={formData.instagram_url} 
             onChange={handleInputChange}
             disabled={!isFieldEditable("instagram_url")}
+            aria-invalid={Boolean(instagramUrlError)}
+            aria-describedby={instagramUrlError ? "instagram_url-error" : undefined}
           />
+          {instagramUrlError && (
+            <p id="instagram_url-error" role="alert" className="mt-1 text-xs text-destructive">
+              {instagramUrlError}
+            </p>
+          )}
         </div>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -189,17 +210,14 @@ export function CommunityDetailsForm() {
               placeholder="https://..."
               disabled={!isFieldEditable("recruitment_link")}
               required={showRecruitmentLink}
-              onBlur={(e) => {
-                const value = e.target.value.trim();
-                if (value && !isValidUrl(value)) {
-                  toast({
-                    title: "Invalid recruitment URL",
-                    description: "Enter a valid URL starting with https:// or http://",
-                    variant: "destructive",
-                  });
-                }
-              }}
+              aria-invalid={Boolean(recruitmentUrlError)}
+              aria-describedby={recruitmentUrlError ? "recruitment_link-error" : undefined}
             />
+            {recruitmentUrlError && (
+              <p id="recruitment_link-error" role="alert" className="mt-1 text-xs text-destructive">
+                {recruitmentUrlError}
+              </p>
+            )}
           </div>
         )}
                  {isFieldEditable("established") && (

--- a/frontend/src/features/communities/components/community-modal.tsx
+++ b/frontend/src/features/communities/components/community-modal.tsx
@@ -33,6 +33,12 @@ import { useInitializeMedia } from '@/features/media/hooks/use-initialize-media'
 import { campuscurrentAPI } from '@/features/communities/api/communities-api';
 import { useToast } from "@/hooks/use-toast";
 import { LoginModal } from "@/components/molecules/login-modal";
+import {
+  getHttpsUrlError,
+  getInstagramUrlError,
+  getTelegramUrlError,
+  normalizeHttpUrl,
+} from "@/features/communities/utils/url-validation";
 
 interface CommunityModalProps {
   isOpen: boolean;
@@ -80,25 +86,6 @@ export function CommunityModal({
     );
   }
 
-  const isValidUrl = (value: string): boolean => {
-    try {
-      const url = new URL(value);
-      return url.protocol === "http:" || url.protocol === "https:";
-    } catch {
-      return false;
-    }
-  };
-
-  const ensureHttp = (val: string | undefined | null): string | undefined => {
-    if (!val) return undefined;
-    const trimmed = val.trim();
-    if (!trimmed) return undefined;
-    if (!/^https?:\/\//i.test(trimmed)) {
-      return `https://${trimmed}`;
-    }
-    return trimmed;
-  };
-
   const handleSubmit = async (
     formData: CreateCommunityData | EditCommunityData,
     resetForm: () => void
@@ -108,7 +95,9 @@ export function CommunityModal({
     let operationSucceeded = false;
     try {
       const isRecruitmentOpen = (formData as EditCommunityData).recruitment_status === CommunityRecruitmentStatus.open;
-      const link = ensureHttp((formData as EditCommunityData).recruitment_link || "");
+      const link = normalizeHttpUrl((formData as EditCommunityData).recruitment_link || "");
+      const telegramUrl = normalizeHttpUrl(formData.telegram_url);
+      const instagramUrl = normalizeHttpUrl(formData.instagram_url);
 
       if (isRecruitmentOpen && !link) {
         toast({
@@ -119,10 +108,24 @@ export function CommunityModal({
         return;
       }
 
-      if (isRecruitmentOpen && link && !isValidUrl(link)) {
+      const recruitmentUrlError = link ? getHttpsUrlError(link) : undefined;
+      const telegramUrlError = telegramUrl ? getTelegramUrlError(telegramUrl) : undefined;
+      const instagramUrlError = instagramUrl ? getInstagramUrlError(instagramUrl) : undefined;
+
+      if (isRecruitmentOpen && recruitmentUrlError) {
         toast({
           title: "Invalid recruitment URL",
-          description: "Please enter a valid URL starting with https:// or http://",
+          description: recruitmentUrlError,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const socialUrlError = telegramUrlError || instagramUrlError;
+      if (socialUrlError) {
+        toast({
+          title: "Invalid social media URL",
+          description: socialUrlError,
           variant: "destructive",
         });
         return;
@@ -141,8 +144,8 @@ export function CommunityModal({
           email: ((formData as EditCommunityData).email || "").trim() || undefined,
           recruitment_status: (formData as EditCommunityData).recruitment_status,
           established: (formData as EditCommunityData).established,
-          telegram_url: formData.telegram_url,
-          instagram_url: formData.instagram_url,
+          telegram_url: telegramUrl,
+          instagram_url: instagramUrl,
           ...(mediaIdsToDelete.length > 0
             ? { media_ids_to_delete: mediaIdsToDelete }
             : {}),
@@ -203,8 +206,8 @@ export function CommunityModal({
           head: user.user.sub,
           established: (formData as CreateCommunityData).established || new Date().toISOString().split('T')[0],
           description: formData.description || "",
-          telegram_url: formData.telegram_url || undefined,
-          instagram_url: formData.instagram_url || undefined,
+          telegram_url: telegramUrl,
+          instagram_url: instagramUrl,
         };
 
         // Only include recruitment_link when status is open and link is non-empty
@@ -373,4 +376,3 @@ function CommunityActionsWrapper({
     />
   );
 }
-

--- a/frontend/src/features/communities/utils/url-validation.test.ts
+++ b/frontend/src/features/communities/utils/url-validation.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  getHttpsUrlError,
+  getInstagramUrlError,
+  getTelegramUrlError,
+  normalizeHttpUrl,
+} from "./url-validation";
+
+describe("community URL validation", () => {
+  it("normalizes domains without changing explicit schemes", () => {
+    assert.equal(normalizeHttpUrl(" t.me/community "), "https://t.me/community");
+    assert.equal(normalizeHttpUrl("http://t.me/community"), "http://t.me/community");
+    assert.equal(normalizeHttpUrl("wtf://t.me/community"), "wtf://t.me/community");
+    assert.equal(normalizeHttpUrl("  "), undefined);
+  });
+
+  it("accepts only Telegram hosts, including www", () => {
+    for (const value of [
+      "https://t.me/community",
+      "https://www.t.me/community",
+      "http://telegram.me/community",
+    ]) {
+      assert.equal(getTelegramUrlError(value), undefined);
+    }
+
+    for (const value of [
+      "https://telegram.org/community",
+      "https://evil.t.me/community",
+      "https://t.me:invalid/community",
+      "wtf://t.me/community",
+      "https://wtf://t.me/community",
+    ]) {
+      assert.equal(getTelegramUrlError(value), "Enter a Telegram URL");
+    }
+  });
+
+  it("accepts only Instagram hosts, including www", () => {
+    for (const value of [
+      "https://instagram.com/community",
+      "https://www.instagram.com/community",
+      "http://instagr.am/community",
+    ]) {
+      assert.equal(getInstagramUrlError(value), undefined);
+    }
+
+    for (const value of [
+      "https://help.instagram.com/community",
+      "https://evil.instagr.am/community",
+      "wtf://instagram.com/community",
+      "https://wtf://instagram.com/community",
+    ]) {
+      assert.equal(getInstagramUrlError(value), "Enter an Instagram URL");
+    }
+  });
+
+  it("requires HTTPS for recruitment links", () => {
+    assert.equal(getHttpsUrlError("https://example.com/apply"), undefined);
+    assert.equal(getHttpsUrlError("http://example.com/apply"), "Enter an HTTPS URL");
+    assert.equal(getHttpsUrlError("https://wtf://example.com"), "Enter an HTTPS URL");
+  });
+});

--- a/frontend/src/features/communities/utils/url-validation.ts
+++ b/frontend/src/features/communities/utils/url-validation.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+const allowedSocialHosts = {
+  telegram: new Set([
+    "t.me",
+    "telegram.me",
+  ]),
+  instagram: new Set([
+    "instagram.com",
+    "instagr.am",
+  ]),
+};
+
+function hasSingleSchemeDelimiter(value: string): boolean {
+  const firstDelimiter = value.indexOf("://");
+  return firstDelimiter !== -1 && firstDelimiter === value.lastIndexOf("://");
+}
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+const httpUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine(
+    (value) => {
+      const url = parseUrl(value);
+      return Boolean(
+        url &&
+          (url.protocol === "http:" || url.protocol === "https:") &&
+          hasSingleSchemeDelimiter(value),
+      );
+    },
+    { message: "Enter a valid URL" },
+  );
+
+const httpsUrlSchema = httpUrlSchema.refine(
+  (value) => parseUrl(value)?.protocol === "https:",
+  { message: "Enter an HTTPS URL" },
+);
+
+function createSocialUrlSchema(hostnames: Set<string>) {
+  return httpUrlSchema.refine(
+    (value) => {
+      const url = parseUrl(value);
+      const hostname = url?.hostname.toLowerCase().replace(/^www\./, "");
+      return Boolean(hostname && hostnames.has(hostname));
+    },
+  );
+}
+
+const telegramUrlSchema = createSocialUrlSchema(allowedSocialHosts.telegram);
+const instagramUrlSchema = createSocialUrlSchema(allowedSocialHosts.instagram);
+
+export function normalizeHttpUrl(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return /^[a-z][a-z\d+.-]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+function getValidationError(
+  schema: z.ZodType<string>,
+  value: string,
+  message: string,
+): string | undefined {
+  const result = schema.safeParse(value);
+  return result.success ? undefined : message;
+}
+
+export function getHttpsUrlError(value: string): string | undefined {
+  return getValidationError(httpsUrlSchema, value, "Enter an HTTPS URL");
+}
+
+export function getTelegramUrlError(value: string): string | undefined {
+  return getValidationError(telegramUrlSchema, value, "Enter a Telegram URL");
+}
+
+export function getInstagramUrlError(value: string): string | undefined {
+  return getValidationError(instagramUrlSchema, value, "Enter an Instagram URL");
+}


### PR DESCRIPTION
## 📝 Description

Improves URL validation in the Community creation and editing forms.

- Normalizes URLs before submission without modifying input while typing
- Shows inline validation errors without crashing the page
- Allows only supported Telegram and Instagram domains
- Supports allowed domains with the www. prefix
- Requires HTTPS for recruitment links
- Rejects malformed URLs such as https://wtf://...
- Adds matching backend validation to prevent API bypass
- Adds frontend and backend regression tests

## 🏷️ Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update

## 🧪 Testing

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [ ] No new warnings

Frontend URL validation: 4 tests passed.
Backend URL validation: 16 tests passed.
Production frontend build completed successfully.

## 🔗 Related Issues

N/A