### PR TITLE
fix(dev): derive Vite HMR client origin

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,10 +2,6 @@ import path from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const tunnelUrl = process.env.VITE_BASE_URL || 'http://localhost:5173'
-const tunnelHost = new URL(tunnelUrl).hostname
-const tunnelProtocol = new URL(tunnelUrl).protocol
-
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -31,9 +27,6 @@ export default defineConfig({
       },
     },
     hmr: {
-      host: tunnelHost,
-      protocol: tunnelProtocol === 'https:' ? 'wss' : 'ws',
-      clientPort: tunnelProtocol === 'https:' ? 443 : 80,
       timeout: 30000,
       overlay: true,
     },


### PR DESCRIPTION
## 📝 Description

Fixes Vite HMR WebSocket connections in the development environment.

Previously, the frontend selected one HMR address from VITE_BASE_URL when the container started. When the Cloudflare tunnel was available,
Vite used the tunnel address even if the site was opened through localhost, causing the HMR WebSocket connection to fail.

This change removes only the fixed HMR host, protocol, and port. Vite can now use the address from which the page was opened:

- localhost uses a local WebSocket connection
- Cloudflare tunnel uses the tunnel WebSocket connection

HMR remains enabled with the existing timeout and error overlay settings. Production is unaffected because these options apply only to the
Vite development server.

## 🏷️ Type of Change

- [x] 🐛 Bug fix

## 🧪 Testing

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] No new warnings

Verified that:

- Vite derives the HMR hostname and protocol from the current page
- The frontend development server starts successfully
- The production frontend build completes successfully

## 🔗 Related Issues

N/A