### PR TITLE
fix(frontend): support opacity modifiers in theme colors

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,31 +16,31 @@
 
 @layer base {
   :root {
-    --background: oklch(0.985 0.006 255);
-    --foreground: oklch(0.235 0.032 258);
-    --card: oklch(0.998 0.003 255);
-    --card-foreground: oklch(0.235 0.032 258);
-    --popover: oklch(0.998 0.003 255);
-    --popover-foreground: oklch(0.235 0.032 258);
-    --primary: oklch(0.48 0.155 260);
-    --primary-foreground: oklch(0.985 0.006 255);
-    --secondary: oklch(0.945 0.014 255);
-    --secondary-foreground: oklch(0.31 0.045 258);
-    --muted: oklch(0.945 0.012 255);
-    --muted-foreground: oklch(0.48 0.035 258);
-    --accent: oklch(0.925 0.025 255);
-    --accent-foreground: oklch(0.31 0.055 260);
-    --success: oklch(0.49 0.105 178);
-    --success-foreground: oklch(0.985 0.01 178);
-    --warning: oklch(0.7 0.145 72);
-    --warning-foreground: oklch(0.25 0.055 65);
-    --destructive: oklch(0.55 0.205 27);
-    --destructive-foreground: oklch(0.985 0.006 27);
-    --disabled: oklch(0.91 0.01 255);
-    --disabled-foreground: oklch(0.51 0.025 258);
-    --border: oklch(0.86 0.018 255);
-    --input: oklch(0.82 0.024 255);
-    --ring: oklch(0.65 0.185 45);
+    --background: 0.985 0.006 255;
+    --foreground: 0.235 0.032 258;
+    --card: 0.998 0.003 255;
+    --card-foreground: 0.235 0.032 258;
+    --popover: 0.998 0.003 255;
+    --popover-foreground: 0.235 0.032 258;
+    --primary: 0.48 0.155 260;
+    --primary-foreground: 0.985 0.006 255;
+    --secondary: 0.945 0.014 255;
+    --secondary-foreground: 0.31 0.045 258;
+    --muted: 0.945 0.012 255;
+    --muted-foreground: 0.48 0.035 258;
+    --accent: 0.925 0.025 255;
+    --accent-foreground: 0.31 0.055 260;
+    --success: 0.49 0.105 178;
+    --success-foreground: 0.985 0.01 178;
+    --warning: 0.7 0.145 72;
+    --warning-foreground: 0.25 0.055 65;
+    --destructive: 0.55 0.205 27;
+    --destructive-foreground: 0.985 0.006 27;
+    --disabled: 0.91 0.01 255;
+    --disabled-foreground: 0.51 0.025 258;
+    --border: 0.86 0.018 255;
+    --input: 0.82 0.024 255;
+    --ring: 0.65 0.185 45;
     --radius-control: 0.5rem;
     --radius-panel: 0.75rem;
     --radius: var(--radius-panel);
@@ -50,31 +50,31 @@
   }
 
   .dark {
-    --background: oklch(0.18 0.022 258);
-    --foreground: oklch(0.94 0.012 255);
-    --card: oklch(0.225 0.025 258);
-    --card-foreground: oklch(0.94 0.012 255);
-    --popover: oklch(0.245 0.027 258);
-    --popover-foreground: oklch(0.94 0.012 255);
-    --primary: oklch(0.72 0.13 258);
-    --primary-foreground: oklch(0.18 0.035 260);
-    --secondary: oklch(0.285 0.026 258);
-    --secondary-foreground: oklch(0.91 0.012 255);
-    --muted: oklch(0.285 0.022 258);
-    --muted-foreground: oklch(0.72 0.026 255);
-    --accent: oklch(0.32 0.04 258);
-    --accent-foreground: oklch(0.94 0.012 255);
-    --success: oklch(0.72 0.105 178);
-    --success-foreground: oklch(0.18 0.03 178);
-    --warning: oklch(0.78 0.13 76);
-    --warning-foreground: oklch(0.22 0.045 68);
-    --destructive: oklch(0.68 0.17 27);
-    --destructive-foreground: oklch(0.18 0.035 27);
-    --disabled: oklch(0.27 0.018 258);
-    --disabled-foreground: oklch(0.59 0.022 255);
-    --border: oklch(0.35 0.03 258);
-    --input: oklch(0.42 0.038 258);
-    --ring: oklch(0.76 0.15 55);
+    --background: 0.18 0.022 258;
+    --foreground: 0.94 0.012 255;
+    --card: 0.225 0.025 258;
+    --card-foreground: 0.94 0.012 255;
+    --popover: 0.245 0.027 258;
+    --popover-foreground: 0.94 0.012 255;
+    --primary: 0.72 0.13 258;
+    --primary-foreground: 0.18 0.035 260;
+    --secondary: 0.285 0.026 258;
+    --secondary-foreground: 0.91 0.012 255;
+    --muted: 0.285 0.022 258;
+    --muted-foreground: 0.72 0.026 255;
+    --accent: 0.32 0.04 258;
+    --accent-foreground: 0.94 0.012 255;
+    --success: 0.72 0.105 178;
+    --success-foreground: 0.18 0.03 178;
+    --warning: 0.78 0.13 76;
+    --warning-foreground: 0.22 0.045 68;
+    --destructive: 0.68 0.17 27;
+    --destructive-foreground: 0.18 0.035 27;
+    --disabled: 0.27 0.018 258;
+    --disabled-foreground: 0.59 0.022 255;
+    --border: 0.35 0.03 258;
+    --input: 0.42 0.038 258;
+    --ring: 0.76 0.15 55;
   }
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+const withAlpha = (variable) => `oklch(var(${variable}) / <alpha-value>)`;
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ["class"],
@@ -15,50 +17,50 @@ module.exports = {
     },
     extend: {
       colors: {
-        border: "var(--border)",
-        input: "var(--input)",
-        ring: "var(--ring)",
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        border: withAlpha("--border"),
+        input: withAlpha("--input"),
+        ring: withAlpha("--ring"),
+        background: withAlpha("--background"),
+        foreground: withAlpha("--foreground"),
         primary: {
-          DEFAULT: "var(--primary)",
-          foreground: "var(--primary-foreground)",
+          DEFAULT: withAlpha("--primary"),
+          foreground: withAlpha("--primary-foreground"),
         },
         secondary: {
-          DEFAULT: "var(--secondary)",
-          foreground: "var(--secondary-foreground)",
+          DEFAULT: withAlpha("--secondary"),
+          foreground: withAlpha("--secondary-foreground"),
         },
         success: {
-          DEFAULT: "var(--success)",
-          foreground: "var(--success-foreground)",
+          DEFAULT: withAlpha("--success"),
+          foreground: withAlpha("--success-foreground"),
         },
         warning: {
-          DEFAULT: "var(--warning)",
-          foreground: "var(--warning-foreground)",
+          DEFAULT: withAlpha("--warning"),
+          foreground: withAlpha("--warning-foreground"),
         },
         destructive: {
-          DEFAULT: "var(--destructive)",
-          foreground: "var(--destructive-foreground)",
+          DEFAULT: withAlpha("--destructive"),
+          foreground: withAlpha("--destructive-foreground"),
         },
         disabled: {
-          DEFAULT: "var(--disabled)",
-          foreground: "var(--disabled-foreground)",
+          DEFAULT: withAlpha("--disabled"),
+          foreground: withAlpha("--disabled-foreground"),
         },
         muted: {
-          DEFAULT: "var(--muted)",
-          foreground: "var(--muted-foreground)",
+          DEFAULT: withAlpha("--muted"),
+          foreground: withAlpha("--muted-foreground"),
         },
         accent: {
-          DEFAULT: "var(--accent)",
-          foreground: "var(--accent-foreground)",
+          DEFAULT: withAlpha("--accent"),
+          foreground: withAlpha("--accent-foreground"),
         },
         popover: {
-          DEFAULT: "var(--popover)",
-          foreground: "var(--popover-foreground)",
+          DEFAULT: withAlpha("--popover"),
+          foreground: withAlpha("--popover-foreground"),
         },
         card: {
-          DEFAULT: "var(--card)",
-          foreground: "var(--card-foreground)",
+          DEFAULT: withAlpha("--card"),
+          foreground: withAlpha("--card-foreground"),
         },
       },
       borderRadius: {


### PR DESCRIPTION
## 📝 Description

Fixes incorrect colors in dark mode after migrating the design system to OKLCH.

Tailwind opacity modifiers such as bg-background/70, bg-muted/30, and border-border/60 did not work because the CSS variables
contained complete oklch(...) values.

This change:

- stores separate OKLCH components in CSS variables;
- constructs colors through Tailwind with <alpha-value>;
- restores opacity modifier support across the application;
- fixes light surfaces and unreadable content appearing in dark mode.

## 🏷️ Type of Change

- [x] 🐛 Bug fix

## 🧪 Testing

- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Tests added/updated
- [ ] No new warnings

Automated checks were not run.

## 🔗 Related Issues

N/A