### PR TITLE
feat(frontend): unify page layouts and improve campus feature UX

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -129,6 +129,29 @@
     font-variant-numeric: tabular-nums;
   }
 
+  .scroll-thin {
+    scrollbar-width: thin;
+    scrollbar-color: oklch(var(--border)) oklch(var(--muted));
+  }
+
+  .scroll-thin::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scroll-thin::-webkit-scrollbar-track {
+    background: oklch(var(--muted));
+  }
+
+  .scroll-thin::-webkit-scrollbar-thumb {
+    background-color: oklch(var(--border));
+    border-radius: 9999px;
+  }
+
+  .scroll-thin::-webkit-scrollbar-thumb:hover {
+    background-color: oklch(var(--muted-foreground) / 0.4);
+  }
+
   /* Prevent iOS/Android webview zoom on input focus by enforcing >=16px font-size */
   @media (max-width: 768px) {
 

--- a/frontend/src/components/atoms/page-container.tsx
+++ b/frontend/src/components/atoms/page-container.tsx
@@ -1,0 +1,45 @@
+import { cn } from "../../utils/utils";
+
+type MaxWidth = "prose" | "default" | "wide" | "full";
+type ContainerPadding = "default" | "dense" | "none";
+
+const maxWidthClasses: Record<MaxWidth, string> = {
+  prose: "max-w-3xl",
+  default: "max-w-5xl",
+  wide: "max-w-6xl",
+  full: "",
+};
+
+const paddingClasses: Record<ContainerPadding, string> = {
+  default: "py-8",
+  dense: "py-2 sm:py-4",
+  none: "",
+};
+
+interface PageContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  maxWidth?: MaxWidth;
+  padding?: ContainerPadding;
+  as?: "div" | "main" | "section" | "article" | "header" | "footer";
+}
+
+function PageContainer({
+  className,
+  maxWidth = "default",
+  padding = "none",
+  as: Component = "div",
+  ...props
+}: PageContainerProps) {
+  return (
+    <Component
+      className={cn(
+        "mx-auto w-full px-4 sm:px-6 lg:px-8",
+        paddingClasses[padding],
+        maxWidth !== "full" && maxWidthClasses[maxWidth],
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { PageContainer, type MaxWidth, type ContainerPadding };

--- a/frontend/src/components/atoms/page-header.tsx
+++ b/frontend/src/components/atoms/page-header.tsx
@@ -1,0 +1,30 @@
+import { cn } from "../../utils/utils";
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+  as?: "h1" | "h2";
+}
+
+function PageHeader({
+  title,
+  subtitle,
+  className,
+  as: Heading = "h1",
+}: PageHeaderProps) {
+  return (
+    <div className={cn("mb-6 max-w-2xl", className)}>
+      <Heading className="text-3xl font-bold tracking-tight text-foreground">
+        {title}
+      </Heading>
+      {subtitle && (
+        <p className="mt-2 leading-relaxed text-muted-foreground">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export { PageHeader };

--- a/frontend/src/components/atoms/section.tsx
+++ b/frontend/src/components/atoms/section.tsx
@@ -1,0 +1,29 @@
+import { cn } from "../../utils/utils";
+
+type SectionVariant = "section" | "compact";
+
+const variantClasses: Record<SectionVariant, string> = {
+  section: "py-16 sm:py-20 lg:py-24",
+  compact: "py-8 sm:py-10",
+};
+
+interface SectionProps extends React.HTMLAttributes<HTMLElement> {
+  variant?: SectionVariant;
+  as?: "section" | "div" | "article" | "header" | "footer";
+}
+
+function Section({
+  className,
+  variant = "section",
+  as: Component = "section",
+  ...props
+}: SectionProps) {
+  return (
+    <Component
+      className={cn(variantClasses[variant], className)}
+      {...props}
+    />
+  );
+}
+
+export { Section, type SectionVariant };

--- a/frontend/src/components/molecules/buttons/bind-telegram-button.tsx
+++ b/frontend/src/components/molecules/buttons/bind-telegram-button.tsx
@@ -208,7 +208,7 @@ export function BindTelegramButton() {
         <div className="mt-4 text-center text-xs text-muted-foreground">
           By continuing the registration process, you agree to our{" "}
           <button
-            className="underline text-blue-600 hover:text-blue-800"
+            className="underline text-primary hover:text-primary/80"
             onClick={() => setShowPrivacy(true)}
           >
             Privacy Policy

--- a/frontend/src/components/organisms/about/about-header.tsx
+++ b/frontend/src/components/organisms/about/about-header.tsx
@@ -1,19 +1,11 @@
-import { useTheme } from '@/context/theme-provider-context';
-
 export const AboutHeader = () => {
-  const { theme } = useTheme();
-  const isDark = theme === "dark";
   return (
-    <div className="text-center mb-16">
+    <div className="text-center">
       <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-        About <span className="text-indigo-500">Nuspace</span>
+        About <span className="text-primary">Nuspace</span>
       </h1>
-      <p
-        className={`mt-6 text-xl leading-8 ${
-          isDark ? "text-gray-300" : "text-gray-600"
-        }`}
-      >
-        SuperApp for Nazarbayev University students
+      <p className="mt-6 text-xl leading-8 text-muted-foreground">
+        Your campus platform for Nazarbayev University
       </p>
     </div>
   );

--- a/frontend/src/components/organisms/about/about-us-section.tsx
+++ b/frontend/src/components/organisms/about/about-us-section.tsx
@@ -3,11 +3,9 @@ import { TeamCard } from "@/components/organisms/about/team-card";
 
 export function AboutUsSection() {
   return (
-    <div className="mb-16">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <TeamCard />
-        <ReportCard />
-      </div>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <TeamCard />
+      <ReportCard />
     </div>
   );
 }

--- a/frontend/src/components/organisms/about/mission-section.tsx
+++ b/frontend/src/components/organisms/about/mission-section.tsx
@@ -1,25 +1,15 @@
-import { useTheme } from '@/context/theme-provider-context';
-
 export const MessionSection = () => {
-  const { theme } = useTheme();
-  const isDark = theme === "dark";
   return (
-    <div
-      className={`rounded-2xl p-8 mb-16 ${
-        isDark ? "bg-gray-800" : "bg-white"
-      } shadow-md`}
-    >
+    <div className="rounded-2xl border bg-card p-8">
       <h2 className="text-2xl font-bold mb-6">Mission</h2>
-      <p className={`mb-4 ${isDark ? "text-gray-300" : "text-gray-600"}`}>
-        Nuspace is a single platform for Nazarbayev University students. Our
-        goal is to simplify the daily life of students and make campus life more
-        comfortable.
+      <p className="mb-4 leading-relaxed text-muted-foreground">
+        Nuspace brings together everything a Nazarbayev University student
+        needs: courses, events, contacts, and campus services in one place.
       </p>
-      <p className={`${isDark ? "text-gray-300" : "text-gray-600"}`}>
-        We strive to create a reliable platform that will allow every student of
-        Nazarbayev University to make the most of their time, easily find the
-        necessary things and keep abreast of interesting events and
-        opportunities within the university.
+      <p className="leading-relaxed text-muted-foreground">
+        We build tools that help students make the most of their time at NU —
+        track academics, find events worth attending, and reach the right
+        office without guessing who to contact.
       </p>
     </div>
   );

--- a/frontend/src/components/templates/about-template.tsx
+++ b/frontend/src/components/templates/about-template.tsx
@@ -1,15 +1,23 @@
 import { AboutHeader } from "@/components/organisms/about/about-header";
 import { MessionSection } from "@/components/organisms/about/mission-section";
 import { AboutUsSection } from "@/components/organisms/about/about-us-section";
+import { PageContainer } from "@/components/atoms/page-container";
+import { Section } from "@/components/atoms/section";
 
 export function AboutTemplate() {
   return (
     <div className="min-h-screen">
-      <div className="max-w-5xl mx-auto px-4 py-16 sm:px-6 lg:px-8">
-        <AboutHeader />
-        <MessionSection />
-        <AboutUsSection />
-      </div>
+      <PageContainer maxWidth="prose" as="main">
+        <Section>
+          <AboutHeader />
+        </Section>
+        <Section>
+          <MessionSection />
+        </Section>
+        <Section>
+          <AboutUsSection />
+        </Section>
+      </PageContainer>
     </div>
   );
 }

--- a/frontend/src/features/communities/pages/list.tsx
+++ b/frontend/src/features/communities/pages/list.tsx
@@ -3,6 +3,8 @@
 import { useState, useMemo } from "react";
 import { Calendar, Plus } from "lucide-react";
 import { useSearchParams } from "@/router/navigation";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 
 import { LoginModal } from "@/components/molecules/login-modal";
 import { CommunityCard } from '@/features/communities/components/community-card';
@@ -85,14 +87,9 @@ export default function CommunitiesPage() {
 
   return (
     <MotionWrapper>
-      <div className="container mx-auto px-4 py-8">
-        {/* Page Header */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-2">
-            <div className="pr-4 sm:pr-0">
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Communities</h1>
-              <p className="text-gray-600 dark:text-gray-400">Join communities and connect with like-minded people</p>
-            </div>
+      <PageContainer padding="default">
+        <div className="flex items-center justify-between mb-6">
+          <PageHeader title="Communities" subtitle="Join communities and connect with like-minded people" className="mb-0" />
             <Button
               onClick={() => setIsCreateModalOpen(true)}
               size="sm"
@@ -103,7 +100,6 @@ export default function CommunitiesPage() {
               <span className="sm:hidden">Create</span>
             </Button>
           </div>
-        </div>
 
         {/* Search Bar */}
         <div className="mb-4">
@@ -302,7 +298,7 @@ export default function CommunitiesPage() {
           title="Login Required"
           message="You need to be logged in to follow communities."
         />
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/courses/components/grade-compare-tray.tsx
+++ b/frontend/src/features/courses/components/grade-compare-tray.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X } from "lucide-react";
+import { X, GitCompareArrows, Trash2 } from "lucide-react";
 import { Button } from "@/components/atoms/button";
 import type { GradeStatistics } from "../types";
 import {
@@ -11,7 +11,7 @@ import {
 } from "../utils/grade-utils";
 import { cn } from "@/utils/utils";
 
-const MAX_SELECTIONS = 8;
+const MAX_SELECTIONS = 4;
 
 interface GradeCompareTrayProps {
   selected: GradeStatistics[];
@@ -24,7 +24,6 @@ type MetricRow = {
   key: string;
   label: string;
   values: string[];
-  /** Column indexes that are semantically best for this metric (ties included). */
   highlightIndexes?: Set<number>;
   toneClasses?: Array<string | undefined>;
 };
@@ -36,16 +35,15 @@ const DIFFICULTY_RANK: Record<string, number> = {
   "Very Hard": 3,
 };
 
-/** Indexes tied for the maximum value. */
+const barColors = ["bg-success", "bg-primary", "bg-warning", "bg-destructive/60", "bg-destructive"];
+
 function bestHigherIndexes(values: number[]): Set<number> {
   if (values.length < 2) return new Set();
   const best = Math.max(...values);
-  // Only highlight when there is a real winner vs at least one worse value.
   if (!values.some((v) => v < best)) return new Set();
   return new Set(values.flatMap((v, i) => (v === best ? [i] : [])));
 }
 
-/** Indexes tied for the minimum value. */
 function bestLowerIndexes(values: number[]): Set<number> {
   if (values.length < 2) return new Set();
   const best = Math.min(...values);
@@ -56,6 +54,12 @@ function bestLowerIndexes(values: number[]): Set<number> {
 function chipLabel(item: GradeStatistics) {
   return `${item.course_code} ${item.section} · ${item.term}`;
 }
+
+function gradePercentiles(stats: GradeStatistics): number[] {
+  return [stats.pct_A, stats.pct_B, stats.pct_C, stats.pct_D, stats.pct_F];
+}
+
+const GRADE_LABELS = ["A", "B", "C", "D", "F"];
 
 export function GradeCompareTray({
   selected,
@@ -69,26 +73,10 @@ export function GradeCompareTray({
   const showTable = count >= 2;
 
   const identityRows: MetricRow[] = [
-    {
-      key: "course",
-      label: "Course",
-      values: selected.map((s) => s.course_code),
-    },
-    {
-      key: "section",
-      label: "Section",
-      values: selected.map((s) => s.section),
-    },
-    {
-      key: "term",
-      label: "Term",
-      values: selected.map((s) => s.term),
-    },
-    {
-      key: "faculty",
-      label: "Faculty",
-      values: selected.map((s) => s.faculty?.trim() || "—"),
-    },
+    { key: "course", label: "Course", values: selected.map((s) => s.course_code) },
+    { key: "section", label: "Section", values: selected.map((s) => s.section) },
+    { key: "term", label: "Term", values: selected.map((s) => s.term) },
+    { key: "faculty", label: "Faculty", values: selected.map((s) => s.faculty?.trim() || "—") },
   ];
 
   const difficulties = selected.map((s) => getDifficultyLevel(s.avg_gpa, s.std_dev));
@@ -96,161 +84,222 @@ export function GradeCompareTray({
 
   const metricRows: MetricRow[] = [
     {
-      key: "students",
-      label: "Students",
-      values: selected.map((s) => String(s.grades_count)),
-    },
-    {
       key: "avg_gpa",
       label: "Avg GPA",
       values: selected.map((s) => formatGPA(s.avg_gpa)),
       highlightIndexes: bestHigherIndexes(selected.map((s) => s.avg_gpa)),
     },
     {
-      key: "median",
-      label: "Median",
-      values: selected.map((s) => formatGPA(s.median_gpa)),
-      highlightIndexes: bestHigherIndexes(selected.map((s) => s.median_gpa)),
-    },
-    {
-      key: "std",
-      label: "Std Dev",
-      values: selected.map((s) => `±${s.std_dev.toFixed(2)}`),
-      // Lower variance = more predictable outcomes.
-      highlightIndexes: bestLowerIndexes(selected.map((s) => s.std_dev)),
+      key: "difficulty",
+      label: "Difficulty",
+      values: difficulties,
+      toneClasses: difficulties.map((d) => getDifficultyColorClass(d)),
+      highlightIndexes: bestLowerIndexes(difficultyRanks),
     },
     {
       key: "withdrawal",
       label: "Withdrawal",
       values: selected.map((s) => formatPercentage(s.pct_W_AW)),
-      highlightIndexes: bestLowerIndexes(selected.map((s) => s.pct_W_AW)),
+      highlightIndexes: bestLowerIndexes(selected.map((s) => Number(s.pct_W_AW))),
     },
     {
-      key: "difficulty",
-      label: "Difficulty",
-      values: difficulties,
-      toneClasses: difficulties.map((d) => getDifficultyColorClass(d)),
-      // Easier is better for section shopping.
-      highlightIndexes: bestLowerIndexes(difficultyRanks),
+      key: "median",
+      label: "Median",
+      values: selected.map((s) => formatGPA(s.median_gpa)),
     },
     {
-      key: "pct_A",
-      label: "A %",
-      values: selected.map((s) => formatPercentage(s.pct_A)),
-      highlightIndexes: bestHigherIndexes(selected.map((s) => s.pct_A)),
+      key: "std",
+      label: "Std Dev",
+      values: selected.map((s) => `±${s.std_dev.toFixed(2)}`),
     },
-    {
-      key: "pct_B",
-      label: "B %",
-      values: selected.map((s) => formatPercentage(s.pct_B)),
-    },
-    {
-      key: "pct_C",
-      label: "C %",
-      values: selected.map((s) => formatPercentage(s.pct_C)),
-    },
-    {
-      key: "pct_D",
-      label: "D %",
-      values: selected.map((s) => formatPercentage(s.pct_D)),
-      highlightIndexes: bestLowerIndexes(selected.map((s) => s.pct_D)),
-    },
-    {
-      key: "pct_F",
-      label: "F %",
-      values: selected.map((s) => formatPercentage(s.pct_F)),
-      highlightIndexes: bestLowerIndexes(selected.map((s) => s.pct_F)),
-    },
+    { key: "students", label: "Students", values: selected.map((s) => String(s.grades_count)) },
   ];
 
   const rows = [...identityRows, ...metricRows];
 
   return (
-    <div
-      className={cn(
-        "sticky top-0 z-20 mb-4 border-b border-border bg-background/95 pb-3 pt-1 backdrop-blur supports-[backdrop-filter]:bg-background/90",
-      )}
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <p className="text-sm font-medium">
-            Compare{" "}
-            <span className="tabular-nums text-muted-foreground">
-              {count}/{maxSelections}
-            </span>
-          </p>
-          {count === 1 && (
-            <span className="text-[13px] text-muted-foreground">Select one more to compare</span>
-          )}
-        </div>
-        <Button type="button" size="sm" variant="ghost" className="h-8 text-[13px]" onClick={onClear}>
-          Clear all
-        </Button>
-      </div>
-
-      <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
-        {selected.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            onClick={() => onRemove(item.id)}
-            className="inline-flex max-w-[220px] shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2.5 py-1 text-left text-[12px] transition-colors hover:bg-muted"
-            title="Remove from compare"
-          >
-            <span className="min-w-0 truncate font-medium">{chipLabel(item)}</span>
-            {item.faculty?.trim() && (
-              <span className="min-w-0 truncate text-muted-foreground">{item.faculty}</span>
+    <>
+      <div
+        className={cn(
+          "sticky top-0 z-20 mb-4 border-b border-border bg-background/95 pb-3 pt-1 backdrop-blur supports-[backdrop-filter]:bg-background/90",
+        )}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <p className="text-sm font-medium">
+              Compare{" "}
+              <span className="tabular-nums text-muted-foreground">
+                {count}/{maxSelections}
+              </span>
+            </p>
+            {count === 1 && (
+              <span className="text-[13px] text-muted-foreground">Select one more to compare</span>
             )}
-            <X className="h-3 w-3 shrink-0 text-muted-foreground" />
-          </button>
-        ))}
-      </div>
+          </div>
+          <Button type="button" size="sm" variant="outline" className="h-8 gap-1.5 text-[13px]" onClick={onClear}>
+            <Trash2 className="h-3.5 w-3.5" />
+            Clear all
+          </Button>
+        </div>
 
-      {showTable && (
-        <div className="mt-3 overflow-x-auto rounded-xl border border-border">
-          <table className="w-full min-w-[520px] border-collapse text-left text-[13px]">
-            <thead>
-              <tr className="border-b border-border bg-muted/40">
-                <th className="sticky left-0 z-10 bg-muted/40 px-3 py-2 font-medium text-muted-foreground">
-                  Metric
-                </th>
-                {selected.map((item) => (
-                  <th key={item.id} className="px-3 py-2 font-semibold whitespace-nowrap">
-                    {item.course_code}
-                    <span className="ml-1 font-normal text-muted-foreground">{item.section}</span>
+        <div className="mt-2 flex gap-2 overflow-x-auto pb-1 scroll-thin">
+          {selected.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onRemove(item.id)}
+              className="inline-flex max-w-[220px] shrink-0 items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2.5 py-1 text-left text-[12px] transition-colors hover:bg-muted"
+              title="Remove from compare"
+            >
+              <span className="min-w-0 truncate font-medium">{chipLabel(item)}</span>
+              {item.faculty?.trim() && (
+                <span className="min-w-0 truncate text-muted-foreground">{item.faculty}</span>
+              )}
+              <X className="h-3 w-3 shrink-0 text-muted-foreground" />
+            </button>
+          ))}
+        </div>
+
+        {showTable && (
+          <div className="mt-3 hidden overflow-x-auto rounded-xl border border-border sm:block scroll-thin">
+            <table className="w-full min-w-[520px] border-collapse text-[13px]">
+              <thead>
+                <tr className="border-b border-border bg-muted/40">
+                  <th className="sticky left-0 z-10 bg-muted/40 px-3 py-2 font-medium text-muted-foreground">
+                    Metric
                   </th>
+                  {selected.map((item) => (
+                    <th key={item.id} className="px-3 py-2 font-semibold whitespace-nowrap">
+                      {item.course_code}
+                      <span className="ml-1 font-normal text-muted-foreground">{item.section}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.key} className="border-b border-border last:border-0">
+                    <th className="sticky left-0 z-10 bg-background px-3 py-2 font-medium text-muted-foreground whitespace-nowrap">
+                      {row.label}
+                    </th>
+                    {row.values.map((value, index) => {
+                      const highlighted = Boolean(row.highlightIndexes?.has(index));
+                      return (
+                        <td
+                          key={`${row.key}-${selected[index].id}`}
+                          className={cn(
+                            "px-3 py-2 tabular-nums",
+                            row.toneClasses?.[index],
+                            highlighted && "rounded-md bg-success/15 font-semibold text-success",
+                          )}
+                          title={highlighted ? "Better for this metric" : undefined}
+                        >
+                          {value as string}
+                        </td>
+                      );
+                    })}
+                  </tr>
                 ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr key={row.key} className="border-b border-border last:border-0">
-                  <th className="sticky left-0 z-10 bg-background px-3 py-2 font-medium text-muted-foreground whitespace-nowrap">
-                    {row.label}
-                  </th>
-                  {row.values.map((value, index) => {
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {showTable && (
+          <div className="mt-3 space-y-3 sm:hidden">
+            {selected.map((item, index) => (
+              <div key={item.id} className="rounded-xl border border-border p-3">
+                <p className="text-sm font-semibold">
+                  {item.course_code}
+                  <span className="ml-1 font-normal text-muted-foreground">{item.section}</span>
+                </p>
+                <dl className="mt-2 space-y-1.5">
+                  {rows.map((row) => {
+                    const value = row.values[index];
                     const highlighted = Boolean(row.highlightIndexes?.has(index));
                     return (
-                      <td
-                        key={`${row.key}-${selected[index].id}`}
-                        className={cn(
-                          "px-3 py-2 tabular-nums",
-                          row.toneClasses?.[index],
-                          highlighted &&
-                            "rounded-md bg-green-500/15 font-semibold text-green-700 dark:text-green-400",
-                        )}
-                        title={highlighted ? "Better for this metric" : undefined}
-                      >
-                        {value}
-                      </td>
+                      <div key={row.key} className="flex items-center justify-between gap-3 text-[13px]">
+                        <dt className="text-muted-foreground">{row.label}</dt>
+                        <dd
+                          className={cn(
+                            "tabular-nums",
+                            row.toneClasses?.[index],
+                            highlighted && "rounded-md bg-success/15 px-1.5 py-0.5 font-semibold text-success",
+                          )}
+                        >
+                          {value}
+                        </dd>
+                      </div>
                     );
                   })}
-                </tr>
+                </dl>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {showTable && (
+          <div className="mt-4 rounded-xl border border-border p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h4 className="text-xs font-medium text-muted-foreground">Grade distribution</h4>
+              <div className="flex items-center gap-3">
+                {GRADE_LABELS.map((label, i) => (
+                  <span key={label} className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                    <span className={cn("h-2 w-2 rounded-full", barColors[i])} />
+                    {label}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="mt-3 space-y-3">
+              {selected.map((item) => (
+                <div key={item.id} className="flex items-center gap-3">
+                  <span className="w-24 shrink-0 truncate text-[13px] font-medium">
+                    {item.course_code}
+                    <span className="ml-1 font-normal text-muted-foreground">{item.section}</span>
+                  </span>
+                  <MiniGradeBar pcts={gradePercentiles(item)} />
+                </div>
               ))}
-            </tbody>
-          </table>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!showTable && count > 0 && (
+        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2">
+          <button
+            type="button"
+            onClick={onClear}
+            className="flex items-center gap-2 rounded-full border border-border bg-background px-4 py-2 text-sm font-medium shadow-lg transition-colors hover:bg-muted"
+          >
+            <GitCompareArrows className="h-4 w-4 text-muted-foreground" />
+            <span>{count} selected — compare</span>
+          </button>
         </div>
       )}
+    </>
+  );
+}
+
+function MiniGradeBar({ pcts }: { pcts: number[] }) {
+  const total = pcts.reduce((s, v) => s + v, 0);
+  if (total <= 0) return <span className="text-muted-foreground">—</span>;
+
+  return (
+    <div className="flex h-5 flex-1 overflow-hidden rounded-full bg-muted">
+      {pcts.map((pct, i) => {
+        if (pct <= 0) return null;
+        const width = total > 0 ? (pct / total) * 100 : 0;
+        return (
+          <div
+            key={GRADE_LABELS[i]}
+            className={cn(barColors[i])}
+            style={{ width: `${width}%` }}
+            title={`${GRADE_LABELS[i]}: ${pct.toFixed(1)}%`}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/features/courses/components/grade-distribution-chart.tsx
+++ b/frontend/src/features/courses/components/grade-distribution-chart.tsx
@@ -13,7 +13,7 @@ export function GradeDistributionChart({ data, title = "Grade Distribution" }: G
     if (active && payload && payload.length) {
       const data = payload[0].payload;
       return (
-        <div className="bg-white dark:bg-gray-800 p-3 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
+        <div className="bg-card p-3 border border-border rounded-lg shadow-lg">
           <p className="font-semibold">{`Grade ${data.grade}`}</p>
           <p className="text-sm">{`${data.percentage.toFixed(1)}% (${data.count} students)`}</p>
         </div>
@@ -31,7 +31,7 @@ export function GradeDistributionChart({ data, title = "Grade Distribution" }: G
               className="w-3 h-3 rounded-full" 
               style={{ backgroundColor: entry.color }}
             />
-            <span className="text-gray-700 dark:text-gray-300">
+            <span className="text-foreground">
               {entry.payload.grade} ({entry.payload.percentage.toFixed(1)}%)
             </span>
           </div>
@@ -42,7 +42,7 @@ export function GradeDistributionChart({ data, title = "Grade Distribution" }: G
 
   return (
     <div className="w-full">
-      <h3 className="text-lg font-semibold text-center mb-4 text-gray-800 dark:text-gray-200">
+      <h3 className="text-lg font-semibold text-center mb-4 text-foreground">
         {title}
       </h3>
       <ResponsiveContainer width="100%" height={300}>

--- a/frontend/src/features/courses/components/grade-statistics-card.tsx
+++ b/frontend/src/features/courses/components/grade-statistics-card.tsx
@@ -1,19 +1,27 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/atoms/card";
+import { Card, CardContent, CardHeader } from "@/components/atoms/card";
 import { Badge } from "@/components/atoms/badge";
 import { Button } from "@/components/atoms/button";
-import { GradeStatistics } from "../types";
-import { 
-  formatGPA, 
-  formatPercentage, 
+import type { GradeStatistics } from "../types";
+import {
+  formatGPA,
+  formatPercentage,
   getGradeDistribution,
   getGPAColorClass,
   getDifficultyLevel,
-  getDifficultyColorClass
-} from '../utils/grade-utils';
-import { GradeDistributionChart } from './grade-distribution-chart';
-import { Users, TrendingUp, BarChart3, User, PieChart, EyeOff, Check, GitCompareArrows } from "lucide-react";
+  getDifficultyColorClass,
+} from "../utils/grade-utils";
+import { GradeDistributionChart } from "./grade-distribution-chart";
+import {
+  Users,
+  TrendingUp,
+  PieChart,
+  EyeOff,
+  Check,
+  GitCompareArrows,
+  AlertTriangle,
+} from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/utils/utils";
 
@@ -25,52 +33,81 @@ interface GradeStatisticsCardProps {
   disableAdd?: boolean;
 }
 
-export function GradeStatisticsCard({ statistics, showChart = true, onToggleSelect, isSelected = false, disableAdd = false }: GradeStatisticsCardProps) {
+const barColors = [
+  "bg-success",
+  "bg-primary",
+  "bg-warning",
+  "bg-destructive/60",
+  "bg-destructive",
+];
+
+export function GradeStatisticsCard({
+  statistics,
+  showChart = true,
+  onToggleSelect,
+  isSelected = false,
+  disableAdd = false,
+}: GradeStatisticsCardProps) {
   const [showPieChart, setShowPieChart] = useState(false);
+  const [justAdded, setJustAdded] = useState(false);
   const gradeDistribution = getGradeDistribution(statistics);
   const difficulty = getDifficultyLevel(statistics.avg_gpa, statistics.std_dev);
   const selectDisabled = Boolean(onToggleSelect) && disableAdd && !isSelected;
+  const withdrawalPct = Number(statistics.pct_W_AW);
+  const totalPct = statistics.pct_A + statistics.pct_B + statistics.pct_C + statistics.pct_D + statistics.pct_F;
+  const grades = [
+    { grade: "A", percent: statistics.pct_A },
+    { grade: "B", percent: statistics.pct_B },
+    { grade: "C", percent: statistics.pct_C },
+    { grade: "D", percent: statistics.pct_D },
+    { grade: "F", percent: statistics.pct_F },
+  ];
+
+  const handleCompare = () => {
+    if (!onToggleSelect) return;
+    onToggleSelect(statistics);
+    setJustAdded(true);
+    setTimeout(() => setJustAdded(false), 1200);
+  };
 
   return (
     <Card
       className={cn(
         "w-full transition-shadow duration-300 hover:shadow-lg",
         isSelected && "ring-2 ring-primary/50 border-primary/40",
+        justAdded && "ring-2 ring-success/50 border-success/40",
       )}
     >
-      <CardHeader className="pb-4 relative">
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-          <div className="flex-1 min-w-0">
-            <CardTitle className="text-xl font-bold text-gray-800 dark:text-gray-200">
-              {statistics.course_code}
-            </CardTitle>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">
-              {statistics.course_title}
-            </p>
-            
-            {/* Faculty Info - moved above badges */}
-            {statistics.faculty && (
-              <div className="flex items-center gap-2 mt-2 text-sm text-gray-600 dark:text-gray-400">
-                <User className="h-4 w-4" />
-                <span className="font-medium">Faculty:</span>
-                <span>{statistics.faculty}</span>
-              </div>
-            )}
-            
-            <div className="flex items-center gap-2 mt-2">
-              <Badge variant="outline" className="text-xs">
-                Section {statistics.section}
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-bold text-foreground truncate">
+                {statistics.course_code}
+              </h3>
+              <Badge variant="outline" className="text-[11px] shrink-0">
+                {statistics.section}
               </Badge>
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="secondary" className="text-[11px] shrink-0">
                 {statistics.term}
               </Badge>
-              <Badge 
-                variant="outline" 
-                className={`text-xs ${getDifficultyColorClass(difficulty)}`}
+              <Badge
+                variant="outline"
+                className={cn("text-[11px] shrink-0", getDifficultyColorClass(difficulty))}
               >
                 {difficulty}
               </Badge>
             </div>
+            <p className="text-sm font-medium text-foreground mt-0.5 line-clamp-1">
+              {statistics.course_title}
+            </p>
+            <p className="text-sm text-muted-foreground mt-1.5">
+              <Users className="inline h-3.5 w-3.5 mr-1 align-text-bottom" />
+              {statistics.faculty && (
+                <span className="font-medium text-foreground">{statistics.faculty} · </span>
+              )}
+              based on {statistics.grades_count} students
+            </p>
           </div>
 
           {onToggleSelect && (
@@ -78,126 +115,94 @@ export function GradeStatisticsCard({ statistics, showChart = true, onToggleSele
               type="button"
               size="sm"
               variant={isSelected ? "default" : "outline"}
-              className="h-8 shrink-0 gap-1.5 rounded-lg text-xs font-medium"
+              className={cn(
+                "h-7 shrink-0 gap-1 rounded-md text-[11px] font-medium px-2.5",
+                justAdded && !isSelected && "border-success text-success",
+              )}
               disabled={selectDisabled}
               aria-pressed={isSelected}
-              onClick={() => onToggleSelect(statistics)}
+              onClick={handleCompare}
             >
               {isSelected ? (
-                <>
-                  <Check className="h-3.5 w-3.5" />
-                  Selected
-                </>
+                <><Check className="h-3 w-3" /> Selected</>
+              ) : justAdded ? (
+                <><Check className="h-3 w-3" /> Added</>
               ) : (
-                <>
-                  <GitCompareArrows className="h-3.5 w-3.5" />
-                  Compare
-                </>
+                <><GitCompareArrows className="h-3 w-3" /> Compare</>
               )}
             </Button>
           )}
         </div>
       </CardHeader>
 
-      <CardContent className="space-y-6">
-        {/* Key Metrics */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <div className="text-center p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-            <div className="flex items-center justify-center mb-1">
-              <Users className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-            </div>
-            <div className="text-lg font-semibold text-blue-600 dark:text-blue-400">
-              {statistics.grades_count}
-            </div>
-            <div className="text-xs text-gray-600 dark:text-gray-400">Students</div>
-          </div>
-
-          <div className="text-center p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-            <div className="flex items-center justify-center mb-1">
-              <TrendingUp className="h-4 w-4 text-green-600 dark:text-green-400" />
-            </div>
-            <div className={`text-lg font-semibold ${getGPAColorClass(statistics.avg_gpa)}`}>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-[1.75rem] font-bold leading-none tabular-nums tracking-tight text-foreground">
               {formatGPA(statistics.avg_gpa)}
-            </div>
-            <div className="text-xs text-gray-600 dark:text-gray-400">Avg GPA</div>
+            </span>
+            <span className="text-xs font-medium text-muted-foreground">GPA</span>
           </div>
 
-          <div className="text-center p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
-            <div className="flex items-center justify-center mb-1">
-              <BarChart3 className="h-4 w-4 text-purple-600 dark:text-purple-400" />
-            </div>
-            <div className="text-lg font-semibold text-purple-600 dark:text-purple-400">
-              {formatGPA(statistics.median_gpa)}
-            </div>
-            <div className="text-xs text-gray-600 dark:text-gray-400">Median</div>
+          <div className="h-6 w-px bg-border" />
+
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <TrendingUp className="h-3.5 w-3.5" />
+            <span>Median <strong className="tabular-nums text-foreground">{formatGPA(statistics.median_gpa)}</strong></span>
           </div>
 
-          <div className="text-center p-3 bg-orange-50 dark:bg-orange-900/20 rounded-lg">
-            <div className="flex items-center justify-center mb-1">
-              <BarChart3 className="h-4 w-4 text-orange-600 dark:text-orange-400" />
-            </div>
-            <div className="text-lg font-semibold text-orange-600 dark:text-orange-400">
-              ±{statistics.std_dev.toFixed(2)}
-            </div>
-            <div className="text-xs text-gray-600 dark:text-gray-400">Std Dev</div>
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <span>
+              ±<strong className="tabular-nums text-foreground">{statistics.std_dev.toFixed(2)}</strong> std dev
+            </span>
           </div>
+
+          <div className="flex items-center gap-1.5 text-sm">
+            <AlertTriangle className={cn("h-3.5 w-3.5", withdrawalPct > 5 ? "text-destructive" : "text-muted-foreground")} />
+            <span className={cn(withdrawalPct > 5 ? "text-destructive" : "text-muted-foreground")}>
+              <strong className="tabular-nums">{formatPercentage(withdrawalPct)}</strong> withdrew
+            </span>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setShowPieChart(!showPieChart)}
+            className="group ml-auto flex shrink-0 items-center gap-1.5 rounded-md py-1 pl-1 pr-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label={showPieChart ? "Hide grade distribution breakdown" : "Show grade distribution breakdown"}
+            title={
+              showPieChart
+                ? "Hide breakdown"
+                : grades
+                    .filter((g) => g.percent > 0)
+                    .map((g) => `${g.grade}: ${formatPercentage(g.percent)}`)
+                    .join(" · ")
+            }
+          >
+            <div className="relative h-2 w-40 overflow-hidden rounded-full bg-muted ring-1 ring-transparent transition-shadow group-hover:ring-border">
+              {grades.map(({ grade, percent }, i) => {
+                if (percent <= 0) return null;
+                const width = totalPct > 0 ? (percent / totalPct) * 100 : 0;
+                const prevWidth = grades
+                  .slice(0, i)
+                  .reduce((sum, g) => sum + (totalPct > 0 ? (g.percent / totalPct) * 100 : 0), 0);
+                return (
+                  <div
+                    key={grade}
+                    className={cn("absolute inset-y-0 first:rounded-l-full last:rounded-r-full", barColors[i])}
+                    style={{ left: `${prevWidth}%`, width: `${width}%` }}
+                  />
+                );
+              })}
+            </div>
+            <span className="text-[11px] font-medium underline decoration-dotted underline-offset-2">
+              {showPieChart ? "Hide" : "Breakdown"}
+            </span>
+            {showPieChart ? <EyeOff className="h-3.5 w-3.5" /> : <PieChart className="h-3.5 w-3.5" />}
+          </button>
         </div>
 
-        {/* Withdrawal Rate */}
-        <div className="text-center p-3 bg-red-50 dark:bg-red-900/20 rounded-lg">
-          <div className="flex items-center justify-center mb-1">
-            <Users className="h-4 w-4 text-red-600 dark:text-red-400" />
-          </div>
-          <div className="text-lg font-semibold text-red-600 dark:text-red-400">
-            {formatPercentage(statistics.pct_W_AW)}
-          </div>
-          <div className="text-xs text-gray-600 dark:text-gray-400">Withdrawal Rate</div>
-        </div>
-
-        {/* Grade Percentages */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">Grade Distribution</h4>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowPieChart(!showPieChart)}
-              className="flex items-center gap-2 text-xs"
-            >
-              {showPieChart ? (
-                <>
-                  <EyeOff className="h-3 w-3" />
-                  Hide Chart
-                </>
-              ) : (
-                <>
-                  <PieChart className="h-3 w-3" />
-                  Show Chart
-                </>
-              )}
-            </Button>
-          </div>
-          <div className="grid grid-cols-5 gap-2 text-center">
-            {[
-              { grade: 'A', percent: statistics.pct_A, color: 'text-green-600 dark:text-green-400' },
-              { grade: 'B', percent: statistics.pct_B, color: 'text-blue-600 dark:text-blue-400' },
-              { grade: 'C', percent: statistics.pct_C, color: 'text-amber-600 dark:text-amber-400' },
-              { grade: 'D', percent: statistics.pct_D, color: 'text-orange-600 dark:text-orange-400' },
-              { grade: 'F', percent: statistics.pct_F, color: 'text-red-600 dark:text-red-400' },
-            ].map(({ grade, percent, color }) => (
-              <div key={grade} className="p-2 bg-gray-50 dark:bg-gray-800 rounded">
-                <div className={`text-sm font-semibold ${color}`}>{grade}</div>
-                <div className="text-xs text-gray-600 dark:text-gray-400">
-                  {formatPercentage(percent)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Chart - now controlled by showPieChart state */}
         {showPieChart && showChart && gradeDistribution.length > 0 && (
-          <div className="pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="pt-4 border-t border-border">
             <GradeDistributionChart data={gradeDistribution} title="" />
           </div>
         )}

--- a/frontend/src/features/courses/components/live-gpa-tab.tsx
+++ b/frontend/src/features/courses/components/live-gpa-tab.tsx
@@ -232,12 +232,13 @@ export function LiveGpaTab({ user, login, viewModel }: LiveGpaTabProps) {
       />
 
       {!user ? (
-        <div className={cn("flex items-center justify-between rounded-[18px] border p-4", coursesSurface.cardLg)}>
-          <div>
-            <p className="text-sm font-semibold">Sign in to track your course progress this semester.</p>
-            <p className="text-xs text-muted-foreground">We will save your course progress for you in your account.</p>
+        <div className={cn("rounded-lg p-6 text-center text-sm text-muted-foreground", coursesSurface.cardLg)}>
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Calculator className="h-6 w-6" aria-hidden="true" />
           </div>
-          <Button onClick={login} size="sm">
+          <h2 className="text-lg font-bold text-foreground">Sign in to track your courses</h2>
+          <p className="mt-1">We will save your course progress in your account.</p>
+          <Button onClick={login} size="sm" className="mt-5">
             Login
           </Button>
         </div>
@@ -261,7 +262,7 @@ export function LiveGpaTab({ user, login, viewModel }: LiveGpaTabProps) {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-[260px_minmax(0,1fr)_300px] xl:items-start">
-          <div className="min-w-0 xl:sticky xl:top-4">
+          <div className="order-2 min-w-0 xl:order-1 xl:sticky xl:top-4">
             <RegisteredCourseList
               courses={registeredCourses}
               gpaExclusion={gpaExclusion}
@@ -279,7 +280,7 @@ export function LiveGpaTab({ user, login, viewModel }: LiveGpaTabProps) {
             />
           </div>
 
-          <div className="min-w-0">
+          <div className="order-1 min-w-0 xl:order-2">
             <CourseWorkspace
               course={selectedCourse}
               isExcludedFromGpa={selectedCourse?.isExcludedFromGpa ?? false}
@@ -292,7 +293,7 @@ export function LiveGpaTab({ user, login, viewModel }: LiveGpaTabProps) {
             />
           </div>
 
-          <aside className="min-w-0 xl:sticky xl:top-4">
+          <aside className="order-3 min-w-0 xl:order-3 xl:sticky xl:top-4">
             <CoursesContextPanel
               selectedCourse={selectedCourse}
               schedule={schedule.data}

--- a/frontend/src/features/courses/components/live-gpa/registered-course-list.tsx
+++ b/frontend/src/features/courses/components/live-gpa/registered-course-list.tsx
@@ -24,11 +24,20 @@ export function RegisteredCourseList({
   onSelectCourse,
   footer,
 }: RegisteredCourseListProps) {
+  const excludedCount = courses.filter(
+    (c) => c.isExcludedFromGpa ?? gpaExclusion.isExcluded(c.id),
+  ).length;
+
   return (
     <div className={cn("flex flex-col p-3", coursesSurface.cardLg)}>
       <div className="mb-3 flex items-center gap-2 px-0.5">
         <h2 className="text-sm font-semibold">Courses</h2>
         <span className={coursesSurface.badge}>{courses.length}</span>
+        {excludedCount > 0 && (
+          <span className="ml-auto text-[11px] text-muted-foreground">
+            {excludedCount} excluded from GPA
+          </span>
+        )}
       </div>
 
       <div className="min-h-0 flex-1 space-y-1">

--- a/frontend/src/features/courses/components/live-gpa/summary-cards.tsx
+++ b/frontend/src/features/courses/components/live-gpa/summary-cards.tsx
@@ -38,18 +38,14 @@ export function SummaryCards({ metrics }: SummaryCardsProps) {
 
       <div className="min-w-0 flex-1 sm:min-w-[180px] sm:px-2">
         <div className="relative h-2 w-full overflow-hidden rounded-full bg-muted">
-          {/* Soft fill up to projected (remaining potential context) */}
           <div
             className="absolute inset-y-0 left-0 rounded-full bg-primary/25"
-            style={{ width: toPercent(Math.max(projected, current)) }}
+            style={{ width: toPercent(projected) }}
           />
-          {/* Solid fill for current GPA */}
           <div
             className="absolute inset-y-0 left-0 rounded-full bg-primary"
             style={{ width: toPercent(current) }}
           />
-          <Marker position={projected} label="Projected" />
-          <Marker position={maxPossible} label="Max possible" />
         </div>
         <div className="mt-1.5 flex w-full justify-between gap-4 text-[11px] tabular-nums text-muted-foreground">
           <span>0.0</span>
@@ -62,18 +58,6 @@ export function SummaryCards({ metrics }: SummaryCardsProps) {
         <MetricStack icon={Target} label="Max possible" value={maxPossible.toFixed(2)} />
       </div>
     </div>
-  );
-}
-
-function Marker({ position, label }: { position: number; label: string }) {
-  if (position <= 0) return null;
-
-  return (
-    <div
-      className="absolute top-1/2 z-10 h-3.5 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground shadow-sm"
-      style={{ left: toPercent(position) }}
-      title={`${label}: ${position.toFixed(2)}`}
-    />
   );
 }
 

--- a/frontend/src/features/courses/components/schedule-builder-tab.tsx
+++ b/frontend/src/features/courses/components/schedule-builder-tab.tsx
@@ -21,7 +21,7 @@ import {
   PlannerCourseAddPayload,
   PlannerCourseSearchResult,
 } from "../types";
-import { Loader2, RefreshCcw, Trash2, Wand2, X } from "lucide-react";
+import { Loader2, RefreshCcw, RotateCcw, Trash2, Wand2, X } from "lucide-react";
 import { ConfirmationModal } from './confirmation-modal';
 import { useSyllabusLinks } from '../utils/use-syllabus-links';
 
@@ -545,7 +545,7 @@ export const ScheduleBuilderTab = ({ user, login }: ScheduleBuilderTabProps) => 
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-6 xl:flex-row">
-        <aside className="w-full space-y-4 lg:w-80">
+        <aside className="w-full space-y-4 xl:w-80">
         <section className="rounded-xl border border-border/60 bg-card p-4 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <h3 className="text-sm font-semibold">Find a course</h3>
@@ -574,7 +574,7 @@ export const ScheduleBuilderTab = ({ user, login }: ScheduleBuilderTabProps) => 
             )}
             {searchOpen && (
               <div className="absolute left-0 right-0 top-full z-20 mt-2 rounded-xl border border-border/60 bg-card shadow-lg">
-                <div className="max-h-80 overflow-auto p-3 space-y-3 text-sm">
+                <div className="max-h-80 overflow-auto p-3 space-y-3 text-sm scroll-thin">
                   {isSearchPending && searchResults.length === 0 ? (
                     <p className="flex items-center gap-2 text-muted-foreground">
                       <Loader2 className="h-4 w-4 animate-spin" /> Searching registrar catalog...
@@ -687,40 +687,49 @@ export const ScheduleBuilderTab = ({ user, login }: ScheduleBuilderTabProps) => 
           </div>
         </section>
 
-        <section className="rounded-xl border border-border/60 bg-card p-4 shadow-sm max-h-[500px] overflow-auto">
-          <div className="flex items-center justify-between gap-3">
+        <section className="scroll-thin rounded-xl border border-border/60 bg-card p-4 shadow-sm max-h-[500px] overflow-y-auto overflow-x-hidden">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <h3 className="text-sm font-semibold">Courses</h3>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5">
               <Button
-                size="sm"
+                size="icon"
                 variant="secondary"
+                className="h-8 w-8"
                 onClick={() => refreshAllCoursesMutation.mutate()}
                 disabled={!planner?.courses.length || refreshAllCoursesMutation.isPending}
+                title="Refresh"
+                aria-label="Refresh courses"
               >
                 {refreshAllCoursesMutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  "Refresh"
+                  <RefreshCcw className="h-4 w-4" />
                 )}
               </Button>
               <Button
-                size="sm"
+                size="icon"
                 variant="secondary"
+                className="h-8 w-8"
                 onClick={() => setResetConfirmOpen(true)}
                 disabled={resetPlannerMutation.isPending}
+                title="Reset"
+                aria-label="Reset planner"
               >
-                Reset
+                <RotateCcw className="h-4 w-4" />
               </Button>
               <Button
-                size="sm"
+                size="icon"
                 variant="secondary"
+                className="h-8 w-8"
                 onClick={() => autoBuildMutation.mutate()}
                 disabled={!planner || autoBuildMutation.isPending}
+                title="Shuffle"
+                aria-label="Auto-build schedule"
               >
                 {autoBuildMutation.isPending ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
-                  "Shuffle"
+                  <Wand2 className="h-4 w-4" />
                 )}
               </Button>
             </div>
@@ -765,7 +774,7 @@ export const ScheduleBuilderTab = ({ user, login }: ScheduleBuilderTabProps) => 
         </section>
         </aside>
 
-        <section className="overflow-x-auto flex-1 rounded-2xl border border-border/60 bg-card p-4 shadow-sm w-[700px] sm:w-vw lg:w-full">
+        <section className="overflow-x-auto flex-1 w-full min-w-0 rounded-2xl border border-border/60 bg-card p-4 shadow-sm scroll-thin">
           <div className="mb-4 flex items-center justify-between">
             <h3 className="text-base font-semibold">Planner preview</h3>
             {selectedEvents.length > 0 && (
@@ -786,11 +795,25 @@ export const ScheduleBuilderTab = ({ user, login }: ScheduleBuilderTabProps) => 
             onShowDetails={setActiveSection}
             activeCourseId={activeCourseId}
           />
+          {activeSection && (
+            <SectionDetailModal
+              sectionEvent={activeSection}
+              onClose={() => setActiveSection(null)}
+              onRemove={() => {
+                const { course, section } = activeSection;
+                const remainingSectionIds = course.sections
+                  .filter((s) => s.is_selected && s.id !== section.id)
+                  .map((s) => s.id);
+                selectSectionMutation.mutate(
+                  { courseId: course.id, sectionIds: remainingSectionIds },
+                  { onSuccess: () => setActiveSection(null) },
+                );
+              }}
+              removing={selectSectionMutation.isPending}
+            />
+          )}
         </section>
       </div>
-      {activeSection && (
-        <SectionDetailModal sectionEvent={activeSection} onClose={() => setActiveSection(null)} />
-      )}
       {activeRequirements && (
         <CourseRequirementModal
           details={activeRequirements}
@@ -934,31 +957,31 @@ const SchedulePreview = ({
   onShowDetails: (sectionEvent: SectionEvent) => void;
   activeCourseId: number | null;
 }) => {
-  if (!schedule) {
-    return (
-      <div className="mt-6 flex h-64 items-center justify-center text-sm text-muted-foreground">
-        Create a schedule to preview blocks.
-      </div>
-    );
-  }
+  const timedEvents = useMemo(
+    () => events.filter(({ section }) => {
+      const [start, end] = parseTimeRange(section.times);
+      return start != null && end != null;
+    }),
+    [events],
+  );
 
-  const hasSections = schedule.courses.some((course) => course.sections.length);
-  const startHour = 8;
-  const endHour = 22; // 10 PM
-  const hourHeight = 75;
-  const hours = Array.from({ length: endHour - startHour + 1 }, (_, idx) => startHour + idx);
-  const maxTimeMinutes = endHour * 60; // 10 PM in minutes (1320)
+  // Grid spans at least the standard campus day (8 AM–10 PM), but widens to fit
+  // any section outside that window instead of silently dropping it.
+  const { startHour, endHour } = useMemo(() => {
+    let minStart = 8 * 60;
+    let maxEnd = 22 * 60;
+    timedEvents.forEach(({ section }) => {
+      const [start, end] = parseTimeRange(section.times);
+      if (start != null) minStart = Math.min(minStart, start);
+      if (end != null) maxEnd = Math.max(maxEnd, end);
+    });
+    return { startHour: Math.floor(minStart / 60), endHour: Math.ceil(maxEnd / 60) };
+  }, [timedEvents]);
 
-  // Filter out events that end after 10 PM
-  const filteredEvents = events.filter(({ section }) => {
-    const [start, end] = parseTimeRange(section.times);
-    if (start == null || end == null) return false;
-    return end <= maxTimeMinutes; // Only include events that end at or before 10 PM
-  });
   const clashingSectionIds = useMemo(() => {
     const clashes = new Set<number>();
     const intervalsByDay: Record<string, Array<{ start: number; end: number; id: number }>> = {};
-    filteredEvents.forEach(({ section }) => {
+    timedEvents.forEach(({ section }) => {
       const [start, end] = parseTimeRange(section.times);
       if (start == null || end == null) {
         return;
@@ -977,7 +1000,20 @@ const SchedulePreview = ({
       });
     });
     return clashes;
-  }, [filteredEvents]);
+  }, [timedEvents]);
+
+  if (!schedule) {
+    return (
+      <div className="mt-6 flex h-64 items-center justify-center text-sm text-muted-foreground">
+        Create a schedule to preview blocks.
+      </div>
+    );
+  }
+
+  const hasSections = schedule.courses.some((course) => course.sections.length);
+  const hourHeight = 75;
+  const hours = Array.from({ length: endHour - startHour + 1 }, (_, idx) => startHour + idx);
+  const filteredEvents = timedEvents;
 
   return (
     <div className="mt-4 space-y-4">
@@ -995,7 +1031,15 @@ const SchedulePreview = ({
             : "Load registrar sections to start visualizing your schedule."}
         </div>
       ) : (
-        <div className="overflow-auto rounded-xl border border-border/60 bg-muted/10 p-4">
+        <>
+        <div className="md:hidden">
+          <ScheduleAgenda
+            events={filteredEvents}
+            clashingSectionIds={clashingSectionIds}
+            onShowDetails={onShowDetails}
+          />
+        </div>
+        <div className="hidden overflow-auto rounded-xl border border-border/60 bg-muted/10 p-4 scroll-thin md:block">
           <div className="grid grid-cols-[60px_repeat(6,minmax(0,1fr))] gap-2 text-xs font-semibold">
             <div />
             {dayDefs.map((day) => (
@@ -1041,7 +1085,7 @@ const SchedulePreview = ({
                         return (
                           <div
                             key={`${section.id}-${day.key}`}
-                            className={`absolute left-1 right-1 cursor-pointer rounded-md px-1.5 py-1 text-[10px] font-semibold shadow transition-all hover:border-blue-500/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${clashClasses}`}
+                            className={`absolute left-1 right-1 cursor-pointer rounded-md px-1.5 py-1 text-[10px] font-semibold shadow transition-all hover:border-primary/50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ${clashClasses}`}
                             style={{
                               top: ((start - startHour * 60) / 60) * hourHeight,
                               height: ((end - start) / 60) * hourHeight,
@@ -1079,6 +1123,113 @@ const SchedulePreview = ({
               </div>
             </div>
           </div>
+        </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+const ScheduleAgenda = ({
+  events,
+  clashingSectionIds,
+  onShowDetails,
+}: {
+  events: SectionEvent[];
+  clashingSectionIds: Set<number>;
+  onShowDetails: (sectionEvent: SectionEvent) => void;
+}) => {
+  const daysWithEvents = dayDefs.filter((day) =>
+    events.some(({ section }) => section.days.includes(day.key)),
+  );
+  const [selectedDay, setSelectedDay] = useState(daysWithEvents[0]?.key ?? dayDefs[0].key);
+
+  useEffect(() => {
+    if (!daysWithEvents.some((d) => d.key === selectedDay) && daysWithEvents[0]) {
+      setSelectedDay(daysWithEvents[0].key);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events]);
+
+  const dayEvents = events
+    .filter(({ section }) => section.days.includes(selectedDay))
+    .map((event) => ({ event, start: parseTimeRange(event.section.times)[0] ?? 0 }))
+    .sort((a, b) => a.start - b.start)
+    .map(({ event }) => event);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-1.5 overflow-x-auto pb-1 scroll-thin">
+        {dayDefs.map((day) => {
+          const hasEvents = daysWithEvents.some((d) => d.key === day.key);
+          return (
+            <button
+              key={day.key}
+              type="button"
+              disabled={!hasEvents}
+              onClick={() => setSelectedDay(day.key)}
+              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                selectedDay === day.key
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : hasEvents
+                    ? "border-border/60 bg-card text-foreground hover:bg-muted"
+                    : "border-border/30 bg-card text-muted-foreground/40"
+              }`}
+            >
+              {day.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {dayEvents.length === 0 ? (
+        <div className="flex h-32 items-center justify-center rounded-xl border border-border/60 bg-muted/10 text-sm text-muted-foreground">
+          No sections on this day.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {dayEvents.map(({ course, section }) => {
+            const demandRatio = computeDemandRatio(section);
+            const slotColors = getDemandClasses(demandRatio);
+            const isClashing = clashingSectionIds.has(section.id);
+            return (
+              <div
+                key={section.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => onShowDetails({ course, section })}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onShowDetails({ course, section });
+                  }
+                }}
+                className={`cursor-pointer rounded-xl border p-3 shadow-sm transition-colors ${
+                  isClashing
+                    ? "border-destructive/70 bg-destructive text-destructive-foreground ring-2 ring-destructive/60"
+                    : `border-border/60 ${slotColors.bg} ${slotColors.text}`
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="font-semibold text-current">
+                    {course.course_code}
+                    <span className="ml-1.5 opacity-80">{section.section_code}</span>
+                  </p>
+                  {section.times && (
+                    <span className="shrink-0 text-xs font-medium text-current opacity-90">
+                      {section.times}
+                    </span>
+                  )}
+                </div>
+                {section.faculty && (
+                  <p className="mt-1 truncate text-xs text-current opacity-80">{section.faculty}</p>
+                )}
+                {section.room && (
+                  <p className="truncate text-xs text-current opacity-80">{section.room}</p>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>
@@ -1186,9 +1337,11 @@ const SectionSelectorBar = ({
 interface SectionDetailModalProps {
   sectionEvent: SectionEvent;
   onClose: () => void;
+  onRemove: () => void;
+  removing: boolean;
 }
 
-const SectionDetailModal = ({ sectionEvent, onClose }: SectionDetailModalProps) => {
+const SectionDetailModal = ({ sectionEvent, onClose, onRemove, removing }: SectionDetailModalProps) => {
   const { course, section } = sectionEvent;
   const selected = section.selected_count ?? 0;
   const enrolled = section.enrollment_snapshot ?? 0;
@@ -1219,29 +1372,40 @@ const SectionDetailModal = ({ sectionEvent, onClose }: SectionDetailModalProps) 
         onClick={(e) => e.stopPropagation()}
         style={{ maxHeight: "calc(100vh - 2rem)" }}
       >
-        <div className="flex items-center justify-between">
+        <div className="flex items-start justify-between gap-3">
           <div>
-            <p className="text-sm font-semibold text-muted-foreground">{course.course_code}</p>
-            <h2 className="text-xl font-bold">{section.section_code}</h2>
+            <p className="text-sm font-semibold text-muted-foreground">
+              {course.course_code}
+              <span className="ml-1.5 font-normal">{section.section_code}</span>
+            </p>
+            <h2 className="text-xl font-bold leading-tight">{course.title || course.course_code}</h2>
           </div>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" onClick={onClose} className="shrink-0">
             <X className="h-4 w-4" />
           </Button>
         </div>
         <div className="mt-4 space-y-3 text-sm">
           <div className="flex justify-between text-muted-foreground">
-            <span>Days</span>
-            <span className="font-medium text-foreground">
+            <span>Days & time</span>
+            <span className="flex items-center gap-2 font-medium text-foreground">
               <DayIndicators days={section.days} />
+              {section.times || "N/A"}
             </span>
           </div>
-          <DetailRow label="Time" value={section.times || "N/A"} />
           <DetailRow label="Room" value={section.room || "TBD"} />
           <DetailRow label="Faculty" value={section.faculty || "TBD"} />
         </div>
         {showBar && (
           <DemandBar capacity={capacity} picked={selected} enrolled={enrolled} />
         )}
+        <Button
+          variant="outline"
+          className="mt-4 w-full text-destructive hover:text-destructive"
+          onClick={onRemove}
+          disabled={removing}
+        >
+          {removing ? "Removing…" : "Remove this section"}
+        </Button>
         <p className="mt-4 text-xs text-muted-foreground">
           Picked counts number of students who have selected this section.
         </p>
@@ -1375,16 +1539,17 @@ const DemandBar = ({
   const safeEnrolled = Math.max(0, Math.min(enrolled, capacity));
   const pickedPercent = capacity > 0 ? (safePicked / capacity) * 100 : 0;
   const enrolledPercent = capacity > 0 ? (safeEnrolled / capacity) * 100 : 0;
+  const markersOverlap = Math.abs(pickedPercent - enrolledPercent) < 4;
   return (
     <div className="mt-6 space-y-3 rounded-2xl border border-border/60 bg-muted/20 p-4 text-xs">
       <div className="relative h-3 rounded-full bg-muted">
         <div
           className="absolute h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-primary shadow"
-          style={{ left: `${pickedPercent}%`, top: "50%" }}
+          style={{ left: `${pickedPercent}%`, top: markersOverlap ? "35%" : "50%" }}
         />
         <div
-          className="absolute h-3 w-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-background bg-muted-foreground/70 shadow"
-          style={{ left: `${enrolledPercent}%`, top: "50%" }}
+          className="absolute h-3 w-3 -translate-x-1/2 -translate-y-1/2 rotate-45 border-2 border-background bg-muted-foreground/70 shadow"
+          style={{ left: `${enrolledPercent}%`, top: markersOverlap ? "65%" : "50%" }}
         />
       </div>
       <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
@@ -1434,15 +1599,24 @@ function computeDemandRatio(section: PlannerSection): number {
 
 function getDemandClasses(ratio: number): { bg: string; text: string } {
   if (ratio >= 1.0) {
-    return { bg: "bg-destructive/30 hover:bg-destructive/40", text: "text-destructive-foreground" };
+    return {
+      bg: "bg-destructive/40 hover:bg-destructive/50 dark:bg-destructive/30 dark:hover:bg-destructive/40",
+      text: "text-destructive-foreground",
+    };
   }
   if (ratio >= 0.75) {
-    return { bg: "bg-amber-200/70 hover:bg-amber-200/80", text: "text-amber-950" };
+    return {
+      bg: "bg-warning/40 hover:bg-warning/50 dark:bg-warning/25 dark:hover:bg-warning/35",
+      text: "text-warning-foreground",
+    };
   }
   if (ratio >= 0.5) {
-    return { bg: "bg-primary/20 hover:bg-primary/30", text: "text-primary-900" };
+    return {
+      bg: "bg-primary/30 hover:bg-primary/40 dark:bg-primary/20 dark:hover:bg-primary/30",
+      text: "text-primary",
+    };
   }
-  return { bg: "bg-blue-500/20 hover:bg-blue-500/30", text: "text-blue-900 dark:text-blue-100" };
+  return { bg: "bg-secondary/60 hover:bg-secondary/80", text: "text-secondary-foreground" };
 }
 
 function truncateFaculty(faculty: string | null | undefined): string {

--- a/frontend/src/features/courses/components/synchronize-courses-control.tsx
+++ b/frontend/src/features/courses/components/synchronize-courses-control.tsx
@@ -196,25 +196,26 @@ export function SynchronizeCoursesControl({
 
   return (
     <>
-      <div className={`inline-flex items-center gap-1.5 ${compact ? "rounded-lg" : "rounded-full"}`}>
+      <div className="inline-flex items-center rounded-lg border border-input">
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
           onClick={() => handleOpen("registrar")}
-          className={`font-medium gap-1.5 ${compact ? "h-8 rounded-lg px-3 text-[13px]" : "rounded-full px-4 gap-2"}`}
+          className="h-8 gap-1.5 rounded-none rounded-l-lg px-3 text-[13px] font-medium"
         >
-          <RefreshCcw className={compact ? "h-3.5 w-3.5" : "h-4 w-4"} />
+          <RefreshCcw className="h-3.5 w-3.5" />
           Sync
         </Button>
+        <div className="h-5 w-px bg-border" />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               size="sm"
-              variant="outline"
-              className={`${compact ? "h-8 rounded-lg px-2" : "rounded-full px-2"}`}
-              aria-label="More sync options"
+              variant="ghost"
+              className="h-8 rounded-none rounded-r-lg px-2"
+              aria-label="More sync options — sync from PDF"
             >
-              <ChevronDown className={compact ? "h-3.5 w-3.5" : "h-4 w-4"} />
+              <ChevronDown className="h-3.5 w-3.5" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="z-[11050]">
@@ -346,13 +347,13 @@ export function SynchronizeCoursesControl({
               <h4 className="text-sm font-semibold text-foreground">Synchronization summary</h4>
               <div className="flex flex-wrap gap-2">
                 <Badge variant="outline">Total: {syncResult.total_synced}</Badge>
-                <Badge variant="outline" className="border-emerald-500/50 text-emerald-600 dark:text-emerald-400">
+                <Badge variant="outline" className="border-success/50 text-success">
                   Added: {syncResult.added_count}
                 </Badge>
-                <Badge variant="outline" className="border-blue-500/50 text-blue-600 dark:text-blue-400">
+                <Badge variant="outline" className="border-primary/50 text-primary">
                   Kept: {syncResult.kept_count}
                 </Badge>
-                <Badge variant="outline" className="border-amber-500/50 text-amber-600 dark:text-amber-400">
+                <Badge variant="outline" className="border-warning/50 text-warning">
                   Removed: {syncResult.deleted_count}
                 </Badge>
               </div>

--- a/frontend/src/features/courses/constants/dashboard-theme.ts
+++ b/frontend/src/features/courses/constants/dashboard-theme.ts
@@ -1,9 +1,9 @@
 /** Tailwind classes aligned with app theme tokens (light + dark). */
 export const coursesSurface = {
   card: "border-border bg-card",
-  cardLg: "rounded-[18px] border border-border bg-card",
-  cardMd: "rounded-[16px] border border-border bg-card",
-  cardSm: "rounded-2xl border border-border bg-card",
+  cardLg: "rounded-lg border border-border bg-card",
+  cardMd: "rounded-md border border-border bg-card",
+  cardSm: "rounded-md border border-border bg-card",
   text: "text-foreground",
   textMuted: "text-muted-foreground",
   badge: "rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground",
@@ -12,7 +12,7 @@ export const coursesSurface = {
   input:
     "border-border bg-background text-foreground placeholder:text-muted-foreground focus-visible:ring-ring",
   rowSelected: "border-border bg-muted/50",
-  iconPrimary: "bg-muted text-muted-foreground",
+  iconPrimary: "bg-primary/10 text-primary",
   tabActive:
     "data-[state=active]:bg-muted data-[state=active]:text-foreground data-[state=active]:after:bg-foreground",
 } as const;
@@ -23,10 +23,18 @@ export const coursesChart = {
   orange: "#f97316",
   red: "#ef4444",
   purple: "#8b5cf6",
-  blue: "hsl(var(--foreground) / 0.35)",
-  muted: "hsl(var(--muted-foreground))",
+  blue: "oklch(var(--foreground) / 0.35)",
+  muted: "oklch(var(--muted-foreground))",
 } as const;
 
+/*
+ * departmentAccents: hardcoded rgba/hex values.
+ * Charts/SVG need raw color strings — can't consume CSS custom properties
+ * the same way Tailwind classes do. Ideally these derive from token values
+ * at runtime (getComputedStyle) or a single chart-safe palette file.
+ * The hash-based fallback means assignment is non-deterministic — not a
+ * designed mapping.
+ */
 const departmentAccents = [
   { bg: "rgba(139,92,246,0.15)", color: coursesChart.purple, label: "Chemistry" },
   { bg: "rgba(34,197,94,0.15)", color: coursesChart.green, label: "Math" },

--- a/frontend/src/features/courses/pages/degree-audit-info-page.tsx
+++ b/frontend/src/features/courses/pages/degree-audit-info-page.tsx
@@ -5,6 +5,7 @@ import Link from "@/router/link";
 
 import MotionWrapper from "@/components/atoms/motion-wrapper";
 import { Button } from "@/components/atoms/button";
+import { PageContainer } from "@/components/atoms/page-container";
 import { ROUTES } from "@/data/routes";
 
 const paragraphs = [
@@ -58,7 +59,7 @@ const steps = [
 export default function DegreeAuditInfoPage() {
   return (
     <MotionWrapper>
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-6">
+      <PageContainer maxWidth="default" padding="default" className="flex flex-col gap-6">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <BookOpenCheck className="h-8 w-8 text-primary" />
@@ -128,7 +129,7 @@ export default function DegreeAuditInfoPage() {
             ))}
           </div>
         </div>
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/courses/pages/grade-statistics-page.tsx
+++ b/frontend/src/features/courses/pages/grade-statistics-page.tsx
@@ -17,6 +17,8 @@ import { ScheduleBuilderTab } from "../components/schedule-builder-tab";
 import { DegreeAuditTab } from "../components/degree-audit-tab";
 import { coursesSurface } from "../constants/dashboard-theme";
 import { cn } from "@/utils/utils";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 
 const tabOptions = [
   { value: "live-gpa", label: "My Courses", icon: BookOpen },
@@ -108,17 +110,12 @@ export default function GradeStatisticsPage() {
 
   return (
     <MotionWrapper>
-      <div className={cn("mx-auto max-w-[1560px] space-y-6 px-2 py-2 sm:px-4 sm:py-4", coursesSurface.text)}>
-        <div className="space-y-1">
-          <h1 className="text-3xl font-semibold tracking-tight">Courses</h1>
-          <p className="text-sm text-muted-foreground">
-            Manage your classes, assignments, GPA and semester planning.
-          </p>
-        </div>
+      <PageContainer maxWidth="full" padding="dense" className={cn("space-y-6", coursesSurface.text)}>
+        <PageHeader title="Courses" subtitle="Manage your classes, assignments, GPA and semester planning." className="mb-0" />
 
         <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
           <div ref={scrollContainerRef} className="overflow-x-auto">
-            <TabsList className={cn("mb-2 inline-flex h-12 w-full min-w-max rounded-[14px] border p-1 sm:w-auto", coursesSurface.card)}>
+            <TabsList className={cn("mb-2 inline-flex h-12 w-full min-w-max rounded-lg border p-1 sm:w-auto", coursesSurface.card)}>
               {tabOptions.map(({ value, label, icon: Icon }) => (
                 <TabsTrigger
                   key={value}
@@ -127,7 +124,7 @@ export default function GradeStatisticsPage() {
                   }}
                   value={value}
                   className={cn(
-                    "relative flex h-10 items-center gap-2 rounded-[10px] px-4 py-2 text-sm text-muted-foreground data-[state=active]:shadow-none after:absolute after:inset-x-3 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-transparent",
+                    "flex h-10 items-center gap-2 rounded-md px-4 py-2 text-sm text-muted-foreground data-[state=active]:shadow-none",
                     coursesSurface.tabActive,
                   )}
                 >
@@ -154,7 +151,7 @@ export default function GradeStatisticsPage() {
             <DegreeAuditTab user={user} login={login} />
           </TabsContent>
         </Tabs>
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/courses/utils/grade-utils.ts
+++ b/frontend/src/features/courses/utils/grade-utils.ts
@@ -75,11 +75,11 @@ export const getDifficultyLevel = (averageGPA: number, stdDeviation: number): st
 
 export const getDifficultyColorClass = (difficulty: string): string => {
   switch (difficulty) {
-    case "Easy": return "text-green-600 dark:text-green-400";
-    case "Moderate": return "text-blue-600 dark:text-blue-400";
-    case "Hard": return "text-orange-600 dark:text-orange-400";
-    case "Very Hard": return "text-red-600 dark:text-red-400";
-    default: return "text-gray-600 dark:text-gray-400";
+    case "Easy": return "text-success";
+    case "Moderate": return "text-primary";
+    case "Hard": return "text-warning";
+    case "Very Hard": return "text-destructive";
+    default: return "text-muted-foreground";
   }
 };
 

--- a/frontend/src/features/events/pages/list.tsx
+++ b/frontend/src/features/events/pages/list.tsx
@@ -6,6 +6,8 @@ import { InfiniteList } from '@/components/virtual/infinite-list';
 import { Event, Community } from "@/features/shared/campus/types";
 import { useState } from "react";
 import { Calendar, ChevronDown, Users, Building2, X } from "lucide-react";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 import { EventModal } from '@/features/events/components/event-modal';
 import { TimeFilter } from '@/features/events/api/events-api';
 import { Button } from "@/components/atoms/button";
@@ -16,6 +18,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/atoms/dropdown-menu";
 import { CommunitySelectionModal } from '@/features/communities/components/community-selection-modal';
+import { TelegramConnectCard } from '@/features/sgotinish/components/telegram-connect-card';
+import { useUser } from '@/hooks/use-user';
 
 const renderEmptyEvents = (
   filterType: string,
@@ -62,6 +66,7 @@ const filterOptions = [
 ];
 
 export default function Events() {
+  const { user } = useUser();
   const [timeFilter, setTimeFilter] = useState<TimeFilter>("upcoming");
   const [eventTypeFilter, setEventTypeFilter] = useState<string | null>(null);
   const [selectedCommunity, setSelectedCommunity] = useState<Community | null>(null);
@@ -92,14 +97,9 @@ export default function Events() {
 
   return (
     <MotionWrapper>
-      <div className="container mx-auto px-4 py-8">
-        {/* Page Header */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-2">
-            <div>
-              <h1 className="text-3xl font-bold tracking-tight">Events</h1>
-              <p className="text-muted-foreground">Find what is happening across campus.</p>
-            </div>
+      <PageContainer padding="default">
+        <div className="flex items-center justify-between mb-6">
+          <PageHeader title="Events" subtitle="Find what is happening across campus." className="mb-0" />
             <Button
               onClick={() => setIsCreateModalOpen(true)}
               size="sm"
@@ -110,9 +110,18 @@ export default function Events() {
               <span className="sm:hidden">Create</span>
             </Button>
           </div>
-        </div>
 
         <main>
+          {user && !user.tg_id && (
+            <TelegramConnectCard
+              user={user}
+              className="mb-6"
+              title="Connect Telegram to publish instantly"
+              description="Create and publish campus events through nuspacebot without extra steps."
+              dismissKey="nuspace_events_tg_banner_dismissed"
+            />
+          )}
+
           {/* Optimized mobile filter section */}
           <div className="mb-6">
             {/* Primary filters - horizontal scrollable on mobile */}
@@ -259,7 +268,7 @@ export default function Events() {
           onClear={handleCommunityRemove}
           selectedCommunityId={selectedCommunity?.id}
         />
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/events/pages/single.tsx
+++ b/frontend/src/features/events/pages/single.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/atoms/button";
+import { PageContainer } from "@/components/atoms/page-container";
 import { Badge } from "@/components/atoms/badge";
 import { EventModal } from '@/features/events/components/event-modal';
 import { CountdownBadge } from '@/features/events/components/countdown-badge';
@@ -149,7 +150,7 @@ const EventDetailView = ({
   handleImageError,
 }: EventDetailViewProps) => {
   return (
-    <div className="container mx-auto pb-20 px-4 max-w-7xl">
+    <PageContainer maxWidth="full" padding="default" className="pb-20">
       <Button
         variant="ghost"
         className="flex items-center gap-2 -ml-3 mb-4 text-muted-foreground hover:text-foreground"
@@ -368,7 +369,7 @@ const EventDetailView = ({
         event={event}
         isEditMode={true}
       />
-    </div>
+    </PageContainer>
   );
 };
 
@@ -385,13 +386,12 @@ const EventDetailErrorState = ({
   isError?: boolean;
   onBack: () => void;
 }) => (
-  <div className="container mx-auto px-4 py-6">
+  <PageContainer padding="default">
     <div className="text-center py-12">
       <h2 className="text-xl font-bold text-destructive mb-4">
         {isError ? "Failed to fetch event details" : "Event not found"}
       </h2>
       <Button onClick={onBack}>Return to Events</Button>
     </div>
-  </div>
-);
-
+  </PageContainer>
+  );

--- a/frontend/src/features/opportunities/pages/opportunities-page.tsx
+++ b/frontend/src/features/opportunities/pages/opportunities-page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { useMutation, useInfiniteQuery } from "@tanstack/react-query";
 import { Search, Loader2, Plus, Eye, EyeOff } from "lucide-react";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 import { createOpportunity, deleteOpportunity, fetchOpportunities, updateOpportunity } from "../api";
 import {
   Opportunity,
@@ -369,15 +371,6 @@ export default function OpportunitiesPage() {
 
   useEffect(() => () => observerRef.current?.disconnect(), []);
 
-  const header = (
-    <div className="flex flex-col gap-2">
-      <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Opportunities Digest</h1>
-      <p className="text-gray-600 dark:text-gray-400">
-        Research opportunities, summer internships, forums and summits are collected specifically for NU students. Majors listed are not strict requirements—feel free to explore other majors if the opportunity fits you. Always double-check details on the official program pages; this list is to help you discover options. Check this page regularly—MRI keeps updating it.
-      </p>
-    </div>
-  );
-
   const handleSubmitForm = (payload: UpsertOpportunityInput) => {
     setSubmitError(null);
     if (editing) {
@@ -400,15 +393,16 @@ export default function OpportunitiesPage() {
   return (
     <MotionWrapper>
       <div className="min-h-screen bg-background">
-        <div className="container mx-auto px-4 py-8 space-y-8">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            {header}
-          </div>
+        <PageContainer padding="default" className="space-y-8">
+          <PageHeader
+            title="Opportunities Digest"
+            subtitle="Research opportunities, summer internships, forums and summits collected specifically for NU students. Majors listed are not strict requirements — always double-check details on the official program pages. Check this page regularly — MRI keeps updating it."
+          />
 
           {/* Filters */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3 rounded-2xl bg-white/90 p-4 shadow-sm border border-gray-200 backdrop-blur dark:bg-background/80 dark:border-border/60">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3 rounded-2xl bg-card p-4 shadow-sm border border-border">
             <div className="sm:col-span-2 md:col-span-2 lg:col-span-3">
-              <Label htmlFor="q" className="text-xs text-gray-500">
+              <Label htmlFor="q" className="text-xs text-muted-foreground">
                 Search
               </Label>
               <div className="relative">
@@ -586,7 +580,7 @@ export default function OpportunitiesPage() {
               )}
             </div>
           )}
-        </div>
+        </PageContainer>
       </div>
     </MotionWrapper>
   );

--- a/frontend/src/features/sgotinish/components/sg-dashboard.tsx
+++ b/frontend/src/features/sgotinish/components/sg-dashboard.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TicketCard } from './ticket-card';
 import { Button } from "@/components/atoms/button";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 import { Filter, Folder, CheckCircle, ChevronDown } from "lucide-react";
 import { useRouter } from "@/router/navigation";
 import MotionWrapper from "@/components/atoms/motion-wrapper";
@@ -154,17 +156,8 @@ export default function SGDashboard() {
 
   return (
     <MotionWrapper>
-      <div className="container mx-auto px-4 py-8">
-
-        {/* Page Header */}
-        <div className="mb-6">
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">SG Dashboard</h1>
-              <p className="text-gray-600 dark:text-gray-400">Manage student appeals and track metrics</p>
-            </div>
-          </div>
-        </div>
+      <PageContainer padding="default">
+        <PageHeader title="SG Dashboard" subtitle="Manage student appeals and track metrics" />
 
         {/* Filters */}
         <div className="mb-6">
@@ -272,7 +265,7 @@ export default function SGDashboard() {
             </div>
           )}
         </div>
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/sgotinish/components/student-dashboard.tsx
+++ b/frontend/src/features/sgotinish/components/student-dashboard.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TicketCard } from './ticket-card';
 import { Button } from "@/components/atoms/button";
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 import { ChevronDown, Filter, Folder, Search } from "lucide-react";
 import { useRouter } from "@/router/navigation";
 import MotionWrapper from "@/components/atoms/motion-wrapper";
@@ -166,18 +168,12 @@ export default function StudentDashboard({ user, createAppealButton }: StudentDa
 
   return (
     <MotionWrapper>
-      <div className="container mx-auto px-4 py-8">
+      <PageContainer padding="default">
 
-        {/* Page Header */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-2">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">My Appeals</h1>
-              <p className="text-gray-600 dark:text-gray-400">Address your concerns directly to the Student Government</p>
-            </div>
-            <div className="flex flex-col sm:flex-row gap-2 items-center">
-              {createAppealButton}
-            </div>
+        <div className="flex items-start justify-between mb-6 gap-4">
+          <PageHeader title="My Appeals" subtitle="Address your concerns directly to the Student Government" className="mb-0 flex-1" />
+          <div className="flex flex-col sm:flex-row gap-2 items-center flex-shrink-0">
+            {createAppealButton}
           </div>
         </div>
 
@@ -288,7 +284,7 @@ export default function StudentDashboard({ user, createAppealButton }: StudentDa
             {createAppealButton}
           </div>
         )}
-      </div>
+      </PageContainer>
     </MotionWrapper>
   );
 }

--- a/frontend/src/features/sgotinish/components/telegram-connect-card.tsx
+++ b/frontend/src/features/sgotinish/components/telegram-connect-card.tsx
@@ -1,38 +1,71 @@
+import { useState } from "react";
+import { X } from "lucide-react";
 import { BindTelegramButton } from "@/components/molecules/buttons/bind-telegram-button";
 import { cn } from "@/utils/utils";
 import { FaTelegram } from "react-icons/fa";
+
+const DISMISS_KEY = "nuspace_tg_banner_dismissed";
 
 interface TelegramConnectCardProps {
   user: {
     tg_id?: string | null;
   } | null;
   className?: string;
+  title?: string;
+  description?: string;
+  dismissKey?: string;
 }
 
-export function TelegramConnectCard({ user, className }: TelegramConnectCardProps) {
-  if (!user || user.tg_id) {
+export function TelegramConnectCard({
+  user,
+  className,
+  title = "Get appeal updates on Telegram",
+  description = "nuspacebot notifies you when your non-anonymous appeals get a response.",
+  dismissKey = DISMISS_KEY,
+}: TelegramConnectCardProps) {
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(dismissKey) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  if (!user || user.tg_id || dismissed) {
     return null;
   }
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem(dismissKey, "true");
+    } catch {}
+    setDismissed(true);
+  };
 
   return (
     <div
       className={cn(
-        "flex flex-col gap-4 rounded-lg border border-blue-200 bg-blue-50/80 p-4 text-blue-950 shadow-sm",
-        "dark:border-blue-900/50 dark:bg-blue-950/40 dark:text-blue-50",
-        "sm:flex-row sm:items-center sm:justify-between",
+        "relative flex flex-col gap-4 overflow-visible rounded-lg border border-primary/20 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between",
         className,
       )}
       data-bind-telegram
     >
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="absolute -right-2.5 -top-2.5 z-10 flex h-6 w-6 items-center justify-center rounded-full border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Dismiss Telegram connect banner"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+
       <div className="flex flex-1 items-start gap-3">
-        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/60 dark:text-blue-300">
+        <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
           <FaTelegram className="h-5 w-5" />
         </div>
-        <div className="space-y-1">
-          <h2 className="text-base font-semibold">Connect Telegram to stay updated</h2>
-          <p className="text-sm text-blue-900/80 dark:text-blue-100/80">
-            Link your Telegram account to receive updates about your non-anonymous appeals directly from nuspacebot
-          </p>
+        <div className="min-w-0 flex-1 space-y-1">
+          <h2 className="text-base font-semibold text-foreground">{title}</h2>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </div>
       </div>
 
@@ -42,4 +75,3 @@ export function TelegramConnectCard({ user, className }: TelegramConnectCardProp
     </div>
   );
 }
-

--- a/frontend/src/features/sgotinish/pages/sgotinish-page.tsx
+++ b/frontend/src/features/sgotinish/pages/sgotinish-page.tsx
@@ -11,6 +11,8 @@ import { CreateAppealButton } from '../components/create-appeal-button';
 import CreateTicketModal from '../components/create-ticket-modal'; // Import the modal
 import { LoginModal } from "@/components/molecules/login-modal";
 import { TelegramConnectCard } from '../components/telegram-connect-card';
+import { PageContainer } from "@/components/atoms/page-container";
+import { PageHeader } from "@/components/atoms/page-header";
 import { Tabs, TabsList, TabsTrigger } from "@/components/atoms/tabs";
 import { SGMembersManagement } from "../components/sg-members-management";
 
@@ -54,15 +56,10 @@ export default function SgotinishPage() {
     }
     if (effectiveDashboard === "sg-members") {
       return (
-        <div className="container mx-auto px-4 py-8">
-          <div className="mb-6">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">SG Members</h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              Manage SG hierarchy and membership permissions.
-            </p>
-          </div>
+        <PageContainer padding="default">
+          <PageHeader title="SG Members" subtitle="Manage SG hierarchy and membership permissions." />
           <SGMembersManagement currentUser={user} />
-        </div>
+        </PageContainer>
       );
     }
 

--- a/frontend/src/page-components/about-page.tsx
+++ b/frontend/src/page-components/about-page.tsx
@@ -3,15 +3,23 @@
 import { AboutHeader } from "@/components/organisms/about/about-header";
 import { MessionSection } from "@/components/organisms/about/mission-section";
 import { AboutUsSection } from "@/components/organisms/about/about-us-section";
+import { PageContainer } from "@/components/atoms/page-container";
+import { Section } from "@/components/atoms/section";
 
 export default function AboutPage() {
   return (
     <div className="min-h-screen">
-      <div className="max-w-5xl mx-auto px-4 py-16 sm:px-6 lg:px-8">
-        <AboutHeader />
-        <MessionSection />
-        <AboutUsSection />
-      </div>
+      <PageContainer maxWidth="prose" as="main">
+        <Section>
+          <AboutHeader />
+        </Section>
+        <Section>
+          <MessionSection />
+        </Section>
+        <Section>
+          <AboutUsSection />
+        </Section>
+      </PageContainer>
     </div>
   );
 }

--- a/frontend/src/page-components/contacts-page.tsx
+++ b/frontend/src/page-components/contacts-page.tsx
@@ -2,21 +2,19 @@
 
 import { ContactsInfoSection } from '@/components/organisms/contacts-info-section'
 import MotionWrapper from '@/components/atoms/motion-wrapper'
+import { PageContainer } from '@/components/atoms/page-container'
+import { PageHeader } from '@/components/atoms/page-header'
 
 export default function ContactsPage() {
   return (
     <MotionWrapper>
-      <main className="container mx-auto max-w-5xl px-4 py-8 sm:py-10">
-        <div className="mb-7 max-w-2xl">
-          <h1 className="text-3xl font-bold tracking-tight text-foreground">
-            Contacts & Essential Services
-          </h1>
-          <p className="mt-2 max-w-[65ch] leading-relaxed text-muted-foreground">
-            Save these contacts. In an emergency, call campus security or local services immediately.
-          </p>
-        </div>
+      <PageContainer as="main" maxWidth="default" padding="default">
+        <PageHeader
+          title="Find the right office or service"
+          subtitle="In an emergency, call campus security or local services immediately."
+        />
         <ContactsInfoSection />
-      </main>
+      </PageContainer>
     </MotionWrapper>
   )
 }

--- a/frontend/src/page-components/landing-page.tsx
+++ b/frontend/src/page-components/landing-page.tsx
@@ -21,6 +21,8 @@ import { useUser } from "@/hooks/use-user";
 import { FeatureCarousel } from "@/components/molecules/feature-carousel";
 import { ROUTES } from "@/data/routes";
 import { cn } from "@/utils/utils";
+import { PageContainer } from "@/components/atoms/page-container";
+import { Section } from "@/components/atoms/section";
 import eventImg1 from "@/assets/images/event_pics/1.webp";
 import eventImg2 from "@/assets/images/event_pics/2.webp";
 import eventImg3 from "@/assets/images/event_pics/3.webp";
@@ -70,7 +72,7 @@ const features: Feature[] = [
       "Find student groups and follow the communities you care about.",
     link: ROUTES.COMMUNITIES.ROOT,
     icon: Users,
-    className: "lg:col-span-2",
+    className: "md:col-span-1 lg:col-span-2",
     iconClassName: "bg-community/15 text-community",
     stripClassName: "bg-community",
     details: ["Student clubs", "Recruitment", "Community events"],
@@ -81,7 +83,7 @@ const features: Feature[] = [
       "Search essential university services, people, and emergency contacts.",
     link: ROUTES.CONTACTS,
     icon: Info,
-    className: "lg:col-span-2",
+    className: "md:col-span-1 lg:col-span-2",
     iconClassName: "bg-contact/15 text-contact",
     stripClassName: "bg-contact",
     details: ["Services", "Emergency contacts", "Search"],
@@ -92,7 +94,7 @@ const features: Feature[] = [
       "Send a request or appeal directly to Student Government and follow its status.",
     link: ROUTES.SGOTINISH.ROOT,
     icon: Shield,
-    className: "lg:col-span-2",
+    className: "md:col-span-1 lg:col-span-2",
     iconClassName: "bg-success/15 text-success",
     stripClassName: "bg-success",
     details: ["Requests", "Appeals", "Status tracking"],
@@ -113,9 +115,9 @@ const onboardingSteps = [
   },
   {
     icon: Check,
-    title: "Get the task done",
+    title: "Get things done on campus",
     description:
-      "Keep your campus information organised without switching between services.",
+      "Courses, events, contacts, and requests — all accessible from one account.",
   },
 ];
 
@@ -125,22 +127,22 @@ export default function LandingPage() {
   return (
     <div className="flex flex-col bg-background text-foreground">
       <main>
-        <section className="relative overflow-hidden px-4 py-24 sm:py-32 lg:py-40">
-          <div className="relative mx-auto max-w-5xl text-center">
+        <section className="relative overflow-hidden py-24 sm:py-32 lg:py-40">
+          <PageContainer className="text-center">
             <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
               <Sparkles className="h-4 w-4" aria-hidden="true" />
               Built by NU students, for NU students
             </div>
 
             <h1 className="mx-auto mb-6 max-w-4xl text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-              Your all-in-one platform for{" "}
-              <span className="text-primary">university life</span>
+              Track grades, find events, and{" "}
+              <span className="text-primary">stay on top of campus</span>
             </h1>
 
             <p className="mx-auto mb-9 max-w-[65ch] text-lg leading-relaxed text-muted-foreground sm:text-xl">
-              Nuspace brings together everything you need at Nazarbayev
-              University: academics, events, communities, and more, in one
-              beautiful, unified experience.
+              Nuspace brings together academics, events, communities, and
+              campus services at Nazarbayev University. Sign in with your
+              NU account and get started.
             </p>
 
             <div className="flex flex-col justify-center gap-3 sm:flex-row">
@@ -176,14 +178,14 @@ export default function LandingPage() {
                 Web and Telegram access
               </span>
             </div>
-          </div>
+          </PageContainer>
         </section>
 
-        <section
+        <Section
           id="features"
-          className="scroll-mt-8 px-4 py-20 sm:py-24"
+          className="scroll-mt-8"
         >
-          <div className="mx-auto max-w-6xl">
+          <PageContainer maxWidth="wide">
             <div className="mb-10 max-w-2xl">
               <p className="mb-3 text-sm font-semibold uppercase tracking-[0.08em] text-primary">
                 Campus toolkit
@@ -256,60 +258,62 @@ export default function LandingPage() {
                 );
               })}
             </div>
-          </div>
-        </section>
+          </PageContainer>
+        </Section>
 
-        <section className="px-4 py-20 sm:py-28">
-          <div className="mx-auto grid max-w-6xl items-center gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:gap-16">
-            <div>
-              <div className="mb-5 flex items-center gap-3">
-                <div className="flex h-11 w-11 items-center justify-center rounded-md bg-warning/15 text-warning-foreground dark:text-warning">
-                  <Calendar className="h-5 w-5" aria-hidden="true" />
+        <Section>
+          <PageContainer maxWidth="wide">
+            <div className="grid items-center gap-10 lg:grid-cols-[0.8fr_1.2fr] lg:gap-16">
+              <div>
+                <div className="mb-5 flex items-center gap-3">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-md bg-warning/15 text-warning-foreground dark:text-warning">
+                    <Calendar className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.08em] text-warning-foreground dark:text-warning">
+                    Campus events
+                  </p>
                 </div>
-                <p className="text-sm font-semibold uppercase tracking-[0.08em] text-warning-foreground dark:text-warning">
-                  Campus events
+                <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                  Know what is happening before you miss it
+                </h2>
+                <p className="mt-4 max-w-[60ch] text-lg leading-relaxed text-muted-foreground">
+                  Browse upcoming events, recruitment announcements, and community
+                  activities in one campus calendar.
                 </p>
+                <ul className="mt-6 space-y-3 text-sm font-medium">
+                  <li className="flex items-center gap-3">
+                    <Check className="h-4 w-4 text-success" aria-hidden="true" />
+                    Filter by date, type, or community
+                  </li>
+                  <li className="flex items-center gap-3">
+                    <Check className="h-4 w-4 text-success" aria-hidden="true" />
+                    Add events to your calendar
+                  </li>
+                  <li className="flex items-center gap-3">
+                    <Check className="h-4 w-4 text-success" aria-hidden="true" />
+                    Discover student-led activities
+                  </li>
+                </ul>
+                <Button variant="outline" asChild className="mt-6 gap-2">
+                  <Link href={ROUTES.EVENTS.ROOT}>
+                    Browse campus events
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </Button>
               </div>
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-                Know what is happening before you miss it
-              </h2>
-              <p className="mt-4 max-w-[60ch] text-lg leading-relaxed text-muted-foreground">
-                Browse upcoming events, recruitment announcements, and community
-                activities in one campus calendar.
-              </p>
-              <ul className="mt-6 space-y-3 text-sm font-medium">
-                <li className="flex items-center gap-3">
-                  <Check className="h-4 w-4 text-success" aria-hidden="true" />
-                  Filter by date, type, or community
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="h-4 w-4 text-success" aria-hidden="true" />
-                  Add events to your calendar
-                </li>
-                <li className="flex items-center gap-3">
-                  <Check className="h-4 w-4 text-success" aria-hidden="true" />
-                  Discover student-led activities
-                </li>
-              </ul>
-              <Button variant="outline" asChild className="mt-6 gap-2">
-                <Link href={ROUTES.EVENTS.ROOT}>
-                  Browse campus events
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </Link>
-              </Button>
-            </div>
 
-            <div className="aspect-[4/3] overflow-hidden rounded-lg border bg-card shadow-sm sm:aspect-video">
-              <FeatureCarousel
-                images={eventImages}
-                alt="Students taking part in a Nazarbayev University campus event"
-              />
+              <div className="aspect-[4/3] overflow-hidden rounded-lg border bg-card shadow-sm sm:aspect-video">
+                <FeatureCarousel
+                  images={eventImages}
+                  alt="Students taking part in a Nazarbayev University campus event"
+                />
+              </div>
             </div>
-          </div>
-        </section>
+          </PageContainer>
+        </Section>
 
-        <section className="px-4 py-20 sm:py-24">
-          <div className="mx-auto max-w-6xl">
+        <Section>
+          <PageContainer maxWidth="wide">
             <div className="grid gap-10 lg:grid-cols-[0.75fr_1.25fr] lg:items-start lg:gap-16">
               <div>
                 <div className="mb-5 flex items-center gap-3">
@@ -363,12 +367,15 @@ export default function LandingPage() {
                 <ArrowRight className="h-5 w-5" aria-hidden="true" />
               </Button>
             </div>
-          </div>
-        </section>
+          </PageContainer>
+        </Section>
       </main>
 
-      <footer className="border-t bg-background px-4 py-8 text-sm text-muted-foreground">
-        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-5 md:flex-row">
+      <footer className="border-t bg-background text-sm text-muted-foreground">
+        <PageContainer
+          as="div"
+          className="flex flex-col items-center justify-between gap-5 py-8 md:flex-row"
+        >
           <p>© {new Date().getFullYear()} Nuspace. Built for the NU community.</p>
           <nav
             aria-label="Footer navigation"
@@ -402,7 +409,7 @@ export default function LandingPage() {
               <Github className="h-3.5 w-3.5" aria-hidden="true" />
             </a>
           </nav>
-        </div>
+        </PageContainer>
       </footer>
     </div>
   );

--- a/frontend/src/page-components/privacy-policy-page.tsx
+++ b/frontend/src/page-components/privacy-policy-page.tsx
@@ -1,4 +1,6 @@
 import { Mail, Phone, ExternalLink } from 'lucide-react'
+import { PageContainer } from '@/components/atoms/page-container'
+import { Section } from '@/components/atoms/section'
 
 const privacyData = {
   title: 'Privacy Policy for nuspace.kz',
@@ -68,30 +70,28 @@ const privacyData = {
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className="container max-w-4xl mx-auto py-12 px-4 space-y-8">
-      {/* Header */}
-      <div className="space-y-4">
-        <h1 className="text-4xl font-bold tracking-tight">{privacyData.title}</h1>
-        <p className="text-muted-foreground">Last updated: {privacyData.lastUpdated}</p>
-        <div className="p-4 bg-muted/50 rounded-lg border border-border">
-          <p className="leading-relaxed">{privacyData.introduction}</p>
+    <PageContainer as="main" maxWidth="prose">
+      <Section variant="compact">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold tracking-tight">{privacyData.title}</h1>
+          <p className="text-muted-foreground">Last updated: {privacyData.lastUpdated}</p>
+          <div className="p-4 bg-muted/50 rounded-lg border border-border">
+            <p className="leading-relaxed">{privacyData.introduction}</p>
+          </div>
         </div>
-      </div>
+      </Section>
 
-      {/* Sections */}
-      <div className="space-y-8">
+      <Section variant="compact" className="space-y-8">
         {privacyData.sections.map((section) => (
           <section key={section.id} className="space-y-3">
             <h2 className="text-2xl font-bold">{section.id}. {section.title}</h2>
 
-            {/* Render Paragraph if description exists */}
             {section.description && (
               <p className="leading-relaxed text-muted-foreground">
                 {section.description}
               </p>
             )}
 
-            {/* Render List if points exist */}
             {section.points && (
               <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                 {section.points.map((point, idx) => (
@@ -101,10 +101,9 @@ export default function PrivacyPolicyPage() {
             )}
           </section>
         ))}
-      </div>
+      </Section>
 
-      {/* Contact */}
-      <div className="mt-12 pt-8 border-t border-border">
+      <Section variant="compact" className="border-t border-border">
         <h2 className="text-2xl font-bold mb-6">Contact Us</h2>
         <p className="text-muted-foreground mb-6">{privacyData.contact.message}</p>
         <div className="grid gap-4 md:grid-cols-3">
@@ -130,7 +129,7 @@ export default function PrivacyPolicyPage() {
             </div>
           </a>
         </div>
-      </div>
-    </div>
+      </Section>
+    </PageContainer>
   )
 }

--- a/frontend/src/page-components/terms-of-service-page.tsx
+++ b/frontend/src/page-components/terms-of-service-page.tsx
@@ -1,4 +1,6 @@
 import { ExternalLink, Mail, Phone } from 'lucide-react'
+import { PageContainer } from '@/components/atoms/page-container'
+import { Section } from '@/components/atoms/section'
 
 const tosData = {
   title: 'Terms of Service for nuspace.kz',
@@ -57,30 +59,28 @@ const tosData = {
 
 export default function TermsOfServicePage() {
   return (
-    <div className="container max-w-4xl mx-auto py-12 px-4 space-y-8">
-      {/* Header */}
-      <div className="space-y-4">
-        <h1 className="text-4xl font-bold tracking-tight">{tosData.title}</h1>
-        <p className="text-muted-foreground">Last updated: {tosData.lastUpdated}</p>
-        <div className="p-4 bg-muted/50 rounded-lg border border-border">
-          <p className="leading-relaxed">{tosData.introduction}</p>
+    <PageContainer as="main" maxWidth="prose">
+      <Section variant="compact">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-bold tracking-tight">{tosData.title}</h1>
+          <p className="text-muted-foreground">Last updated: {tosData.lastUpdated}</p>
+          <div className="p-4 bg-muted/50 rounded-lg border border-border">
+            <p className="leading-relaxed">{tosData.introduction}</p>
+          </div>
         </div>
-      </div>
+      </Section>
 
-      {/* Sections */}
-      <div className="space-y-8">
+      <Section variant="compact" className="space-y-8">
         {tosData.sections.map((section) => (
           <section key={section.id} className="space-y-3">
             <h2 className="text-2xl font-bold">{section.id}. {section.title}</h2>
 
-            {/* Render Description */}
             {section.description && (
               <p className="leading-relaxed text-muted-foreground">
                 {section.description}
               </p>
             )}
 
-            {/* Render List if items exist */}
             {section.items && (
               <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
                 {section.items.map((item, idx) => (
@@ -90,10 +90,9 @@ export default function TermsOfServicePage() {
             )}
           </section>
         ))}
-      </div>
+      </Section>
 
-      {/* Contact */}
-      <div className="mt-12 pt-8 border-t border-border">
+      <Section variant="compact" className="border-t border-border">
         <h2 className="text-2xl font-bold mb-6">Contact</h2>
         <p className="text-muted-foreground mb-6">{tosData.contact.message}</p>
         <div className="grid gap-4 md:grid-cols-3">
@@ -119,7 +118,7 @@ export default function TermsOfServicePage() {
             </div>
           </a>
         </div>
-      </div>
-    </div>
+      </Section>
+    </PageContainer>
   )
 }


### PR DESCRIPTION
- add reusable page container, header, and section primitives
- standardize responsive layouts across public and authenticated pages
- refine landing, about, contacts, events, communities, and opportunities pages
- improve course statistics, grade comparison, and GPA dashboard presentation
- add a mobile agenda and better controls to the schedule builder
- improve schedule conflict, demand, and section detail states
- polish SG Otinish dashboards and Telegram connection experience
- promote Telegram event publishing from the Events page
- add consistent thin scrollbar styling for overflow areas